### PR TITLE
tiebreaker: the one ending later should be printed first

### DIFF
--- a/lib/traces/CDSConsoleExporter.js
+++ b/lib/traces/CDSConsoleExporter.js
@@ -108,13 +108,11 @@ class CDSConsoleExporter /* implements SpanExporter */ {
           const furtherLogsToPrint = this._temporaryStorage.get(span.spanContext().traceId)
           if (furtherLogsToPrint) {
             furtherLogsToPrint
-              // REVISIT: ordering correct?
-              // .sort((a, b) => {
-              //   const d = hrTimeToMilliseconds(a.startTime) - hrTimeToMilliseconds(b.startTime)
-              //   if (d !== 0) return d
-              //   return hrTimeToMilliseconds(b.endTime) - hrTimeToMilliseconds(a.endTime) //> the one ending later should be printed first
-              // })
-              .sort((a, b) => hrTimeToMilliseconds(a.startTime) - hrTimeToMilliseconds(b.startTime))
+              .sort((a, b) => {
+                const d = hrTimeToMilliseconds(a.startTime) - hrTimeToMilliseconds(b.startTime)
+                if (d !== 0) return d
+                return hrTimeToMilliseconds(b.endTime) - hrTimeToMilliseconds(a.endTime) //> the one ending later should be printed first
+              })
               .forEach(t => (toLog += this._exportInfoString(t, true, span.startTime)))
             this._temporaryStorage.delete(span.spanContext().traceId)
           }


### PR DESCRIPTION
closes https://github.com/cap-js/opentelemetry-instrumentation/issues/10

<img width="832" alt="Screenshot 2023-10-23 at 23 38 57" src="https://github.com/cap-js/opentelemetry-instrumentation/assets/30337871/76ee3f9a-c947-4f75-8178-38ad0b3d6c24">
