### PR TITLE
feat: enable custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Predefined kind for SAP Cloud Logging (`telemetry-to-cloud-logging`)
+- Built-in `ConsoleMetricExporter` prints DB pool and other metrics separately
 
 ## Version 0.0.1 - 2024-01-04
 

--- a/lib/exporter/ConsoleMetricExporter.js
+++ b/lib/exporter/ConsoleMetricExporter.js
@@ -4,6 +4,8 @@ const LOG = cds.log('telemetry')
 const { ConsoleMetricExporter: StandardConsoleMetricExporter } = require('@opentelemetry/sdk-metrics')
 const { ExportResultCode } = require('@opentelemetry/core')
 
+const { inspect } = require('util')
+
 class ConsoleMetricExporter extends StandardConsoleMetricExporter {
   export(metrics, resultCallback) {
     if (this._shutdown) {
@@ -12,27 +14,35 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
       return
     }
 
-    // REVISIT: this needs to become more generic once we add more metrics!
     for (const scopeMetrics of metrics.scopeMetrics) {
-      const tenant = scopeMetrics.metrics[0].dataPoints[0].attributes['sap.tenancy.tenant_id']
-
-      let toLog = `db.pool${tenant ? ` of tenant "${tenant}"` : ''}:`
-
-      const size = scopeMetrics.metrics.find(m => m.descriptor.name.match(/size/)).dataPoints[0].value
-      const max = scopeMetrics.metrics.find(m => m.descriptor.name.match(/max/)).dataPoints[0].value
-      // const min = scopeMetrics.metrics.find(m => m.descriptor.name.match(/min/)).dataPoints[0].value
-      const available = scopeMetrics.metrics.find(m => m.descriptor.name.match(/available/)).dataPoints[0].value
-      // const borrowed = scopeMetrics.metrics.find(m => m.descriptor.name.match(/borrowed/)).dataPoints[0].value
-      // const spareResourceCapacity = scopeMetrics.metrics.find(m => m.descriptor.name.match(/spareResourceCapacity/)).dataPoints[0].value
-      const pending = scopeMetrics.metrics.find(m => m.descriptor.name.match(/pending/)).dataPoints[0].value
-
-      toLog += `\n     size | available | pending`
-      toLog += `\n  ${`${size}/${max}`.padStart(7, ' ')} | ${`${available}/${size}`.padStart(
-        9,
-        ' '
-      )} | ${`${pending}`.padStart(7, ' ')}`
-
-      LOG.info(toLog)
+      // split between pool and other metrics
+      const pool = {}, other = {}
+      for (const metric of scopeMetrics.metrics) {
+        const match = metric.descriptor.name.match(/^db\.pool\.(\w+)$/)
+        const name = match ? match[1] : metric.descriptor.name
+        const collector = match ? pool : other
+        for (const dp of metric.dataPoints) {
+          const t = dp.attributes['sap.tenancy.tenant_id']
+          collector[t] ??= {}
+          collector[t][name] = match ? dp.value : dp
+        }
+      }
+      // export pool metrics
+      for (const tenant of Object.keys(pool)) {
+        let toLog = `db.pool${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}:`
+        toLog += `\n     size | available | pending`
+        toLog += `\n  ${`${pool[tenant].size}/${pool[tenant].max}`.padStart(7, ' ')} | ${`${pool[tenant].available}/${pool[tenant].size}`.padStart(
+          9,
+          ' '
+        )} | ${`${pool[tenant].pending}`.padStart(7, ' ')}`
+        LOG.info(toLog)
+      }
+      // export other metrics
+      for(const tenant of Object.keys(other)) {
+        for (const [k, v] of Object.entries(other[tenant])) {
+          LOG.info(`${k}${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}: ${inspect(v)}`)
+        }
+      }
     }
 
     resultCallback({ code: ExportResultCode.SUCCESS })


### PR DESCRIPTION
example custom metric request counter:
```js
const cds = require('@sap/cds')

const { metrics } = require('@opentelemetry/api')

let counter
cds.middlewares.add((req, _, next) => {
  counter.add(1, { 'sap.tenancy.tenant_id': req.tenant })
  next()
})
cds.on('listening', () => {
  /*
   * UNOFFICIAL cds._telemetry.name is the SemanticResourceAttributes.SERVICE_NAME,
   * which CURRENTLY is process.env.OTEL_SERVICE_NAME || PKG?.name || VCAP_APPLICATION?.name || 'CAP Application'
   */
  const meter = metrics.getMeter(`${cds._telemetry.name}-meter`)
  counter = meter.createCounter('req.counter')
})

module.exports = cds.server
```

outputs:
```txt
[telemetry] - req.counter of tenant "t1": {
  attributes: { 'sap.tenancy.tenant_id': 't1' },
  startTime: [ 1705354230, 96000000 ],
  endTime: [ 1705354446, 736000000 ],
  value: 2
}
[telemetry] - req.counter of tenant "t2": {
  attributes: { 'sap.tenancy.tenant_id': 't2' },
  startTime: [ 1705354348, 344000000 ],
  endTime: [ 1705354446, 736000000 ],
  value: 5
}
```