### PR TITLE
feat: support for Dynatrace credentials via user-provided service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Support for exporting traces to Dynatrace via OpenTelemetry exporter (instead of Dynatrace OneAgent)
 - `@opentelemetry/host-metrics` is automatically fired up, if it is in the project's dependencies
+- Support for Dynatrace credentials via user-provided service
 
 ## Version 0.0.2 - 2024-01-15
 

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -9,6 +9,19 @@ const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry
 
 const { getCloudLoggingCredentials, _require } = require('../utils')
 
+function _getDynatrace() {
+  if (!process.env.VCAP_SERVICES) return null
+  const vcap = JSON.parse(process.env.VCAP_SERVICES)
+  if (vcap.dynatrace?.[0]?.credentials) { 
+    return vcap.dynatrace?.[0]?.credentials
+  }
+  //to support connection via user-provided services - APMs requirement is that the instance name contains dynatrace
+  if (vcap['user-provided']?.some(b => b.name.match(/dynatrace/))) {
+    return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
+  }
+  return null
+}
+
 function _getExporter() {
   const metricsExporter = cds.env.requires.telemetry.metrics.exporter
   // use _require for better error message
@@ -17,8 +30,8 @@ function _getExporter() {
   if (!metricsExporterModule[metricsExporter.class])
     throw new Error(`Unknown metrics exporter "${metricsExporter.class}" in module "${metricsExporter.module}"`)
   const metricsConfig = { ...(metricsExporter.config || {}) }
-
-  const dynatrace = process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES).dynatrace?.[0]?.credentials
+  
+  const dynatrace = _getDynatrace()
   if (dynatrace && cds.env.requires.telemetry.kind.match(/dynatrace/)) {
     metricsConfig.url ??= `${dynatrace.apiurl}/v2/otlp/v1/metrics`
     metricsConfig.headers ??= {}

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -37,7 +37,10 @@ function _getExporter() {
     metricsConfig.headers ??= {}
     // dynatrace.rest_apitoken?.token is deprecated and only supported for compatibility reasons
     const token = dynatrace.metrics_apitoken || dynatrace.rest_apitoken?.token
-    if (!token) throw new Error('Neither metrics_apitoken nor rest_apitoken.token found in Dynatrace credentials')
+    if (!token) {
+      LOG.warn('Neither metrics_apitoken nor rest_apitoken.token found in Dynatrace credentials')
+      return;
+    }
     metricsConfig.headers.authorization ??= `Api-Token ${token}`
     metricsConfig.temporalityPreference ??= require('@opentelemetry/sdk-metrics').AggregationTemporality.DELTA
   }

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -7,19 +7,6 @@ const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry
 
 const { getDynatraceMetadata, getDynatraceCredentials, getCloudLoggingCredentials, _require } = require('../utils')
 
-function _getDynatrace() {
-  if (!process.env.VCAP_SERVICES) return null
-  const vcap = JSON.parse(process.env.VCAP_SERVICES)
-  if (vcap.dynatrace?.[0]?.credentials) { 
-    return vcap.dynatrace?.[0]?.credentials
-  }
-  //to support connection via user-provided services - APMs requirement is that the instance name contains dynatrace
-  if (vcap['user-provided']?.some(b => b.name.match(/dynatrace/))) {
-    return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
-  }
-  return null
-}
-
 function _getExporter() {
   const metricsExporter = cds.env.requires.telemetry.metrics.exporter
   // use _require for better error message

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,8 +87,13 @@ function getDynatraceMetadata() {
 }
 
 function getDynatraceCredentials() {
-  // TODO: support credentials via user provided service
-  return process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES).dynatrace?.[0]?.credentials
+  if (!process.env.VCAP_SERVICES) return null
+  const vcap = JSON.parse(process.env.VCAP_SERVICES)
+  if (vcap.dynatrace?.[0]?.credentials) return vcap.dynatrace?.[0]?.credentials
+  // to support connection via user-provided services, APMs requirement is that the instance name contains "dynatrace"
+  if (vcap['user-provided']?.some(b => b.name.match(/dynatrace/)))
+    return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
+  return null
 }
 
 function getCloudLoggingCredentials() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,13 +87,12 @@ function getDynatraceMetadata() {
 }
 
 function getDynatraceCredentials() {
-  if (!process.env.VCAP_SERVICES) return null
+  if (!process.env.VCAP_SERVICES) return
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
   if (vcap.dynatrace?.[0]?.credentials) return vcap.dynatrace?.[0]?.credentials
   // to support connection via user-provided services, APMs requirement is that the instance name contains "dynatrace"
   if (vcap['user-provided']?.some(b => b.name.match(/dynatrace/)))
     return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
-  return null
 }
 
 function getCloudLoggingCredentials() {


### PR DESCRIPTION
According to APM docu for Dynatrace if a Dynatrace service instance cannot be used, a user provided service instance with the name containing "dynatrace" shall be used.

PR adds this support because also we need it in our app :)

BR,
Marten