### PR TITLE
Add support for double export/instrumentation

### DIFF
--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -130,6 +130,11 @@ module.exports = resource => {
     }
   } else {
     LOG._warn && LOG.warn('TracerProvider already initialized by a different module. It will be used as is.')
+    // Add Span Processor with exporter even if TraceProvider was already initialized (double instrumentation/export use case)
+    const exporter = _getExporter()
+    const spanProcessor =
+      process.env.NODE_ENV === 'production' ? new BatchSpanProcessor(exporter) : new SimpleSpanProcessor(exporter)
+    tracerProvider.getDelegate().addSpanProcessor(spanProcessor)
   }
 
   // REVISIT: better way to set/ pass tracer?


### PR DESCRIPTION
Based on my tests in a situation when non cap-js instrumentation was initialized, you still want instrumentation and export setup from cap-js to start.
