### PR TITLE
Add health endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,14 @@ module.exports = function () {
     name: resource.attributes['service.name'],
     version: resource.attributes['service.version']
   }
+  /*
+   * add anounymous health endpoint - required for Kyma
+   */
+  cds.on('bootstrap', app => {
+    app.get('/health', (_, res) => {
+      res.status(200).send('OK')
+    });
+  });
 
   /*
    * add tracing


### PR DESCRIPTION
Currently the docu recommends to add this endpoint yourself. However I think this can be included in the telemetry plugin as it is required for telemetry (availability). 
Kyma requires such an endpoint as colleagues pointed out.

BR, Marten