### PR TITLE
feat!: ignore all `system.*` metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Register span processor also if tracer provider is initialized by a different module
 
+### Changed
+
+- By default, all `system.*` metrics collected by `@opentelemetry/host-metrics` are ignored
+  + Disable change via environment variable `HOST_METRICS_RETAIN_SYSTEM=true`
+
 ## Version 0.0.4 - 2024-02-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Currently, there is no public config option to influence which metrics `@opentel
 However, it is possible to instruct the meter provider during initialization, which metrics shall be ignored.
 By default, this is done for all `system.*` metrics collected by `@opentelemetry/host-metrics`.
 This can be disabled via environment variable `HOST_METRICS_RETAIN_SYSTEM=true`.
+As these so-called *views* must be passed into the constructor, the above only applies in case `@cap-js/telemetry` initializes the meter provider.
 
 To avoid spamming the console, only `process.*` metrics are printed by default, regardless of whether the `system.*` metrics are ignored or not.
 Printing the `system.*` metrics (if not ignored) in the built-in console exporter can be enabled via environment variable `HOST_METRICS_LOG_SYSTEM=true`.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,14 @@ Example db pool metrics printed to the console:
 ```
 
 Additionally, `@cap-js/telemetry` instantiates and starts [`@opentelemetry/host-metrics`](https://www.npmjs.com/package/@opentelemetry/host-metrics) if it is found in the app's dependencies.
-To avoid spamming the console, only `process.*` metrics are printed by default.
-Printing the `system.*` metrics in the built-in console exporter can be enabled via environment variable `HOST_METRICS_LOG_SYSTEM=true`.
-Currently, there is no public config option to influence which metrics `@opentelemetry/host-metrics` sends to a backend.
+
+Currently, there is no public config option to influence which metrics `@opentelemetry/host-metrics` collects.
+However, it is possible to instruct the meter provider during initialization, which metrics shall be ignored.
+By default, this is done for all `system.*` metrics collected by `@opentelemetry/host-metrics`.
+This can be disabled via environment variable `HOST_METRICS_RETAIN_SYSTEM=true`.
+
+To avoid spamming the console, only `process.*` metrics are printed by default, regardless of whether the `system.*` metrics are ignored or not.
+Printing the `system.*` metrics (if not ignored) in the built-in console exporter can be enabled via environment variable `HOST_METRICS_LOG_SYSTEM=true`.
 
 Example host metrics printed to the console:
 ```

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -51,7 +51,8 @@ module.exports = resource => {
   if (meterProvider.constructor.name === 'NoopMeterProvider') {
     const dtmetadata = getDynatraceMetadata()
     resource = new Resource({}).merge(resource).merge(dtmetadata)
-    // unfortunately, we have to pass views to the MeterProvider constructor (something like meterProvider.addView() would be a lot nicer)
+    // unfortunately, we have to pass views to the MeterProvider constructor
+    // something like meterProvider.addView() would be a lot nicer for locality
     let views = []
     if (process.env.HOST_METRICS_RETAIN_SYSTEM) {
       // nothing to do

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -3,7 +3,7 @@ const LOG = cds.log('telemetry')
 
 const { metrics } = require('@opentelemetry/api')
 const { Resource } = require('@opentelemetry/resources')
-const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics')
+const { DropAggregation, MeterProvider, PeriodicExportingMetricReader, View } = require('@opentelemetry/sdk-metrics')
 
 const { getDynatraceMetadata, getDynatraceCredentials, getCloudLoggingCredentials, _require } = require('../utils')
 
@@ -51,7 +51,20 @@ module.exports = resource => {
   if (meterProvider.constructor.name === 'NoopMeterProvider') {
     const dtmetadata = getDynatraceMetadata()
     resource = new Resource({}).merge(resource).merge(dtmetadata)
-    meterProvider = new MeterProvider({ resource })
+    // unfortunately, we have to pass views to the MeterProvider constructor (something like meterProvider.addView() would be a lot nicer)
+    let views = []
+    if (process.env.HOST_METRICS_RETAIN_SYSTEM) {
+      // nothing to do
+    } else {
+      views.push(
+        new View({
+          meterName: '@cap-js/telemetry:host-metrics',
+          instrumentName: 'system.*',
+          aggregation: new DropAggregation()
+        })
+      )
+    }
+    meterProvider = new MeterProvider({ resource, views })
     metrics.setGlobalMeterProvider(meterProvider)
   } else {
     LOG._warn && LOG.warn('MeterProvider already initialized by a different module. It will be used as is.')

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,26 @@
+const cds = require('@sap/cds')
+
+// process.env.HOST_METRICS_RETAIN_SYSTEM = 'true' //> with this the test would fail
+process.env.HOST_METRICS_LOG_SYSTEM = 'true'
+cds.env.requires.telemetry.metrics.config.exportIntervalMillis = 100
+
+const { expect, GET } = cds.test().in(__dirname + '/bookshop')
+const log = cds.test.log()
+
+const wait = require('util').promisify(setTimeout)
+
+describe('metrics', () => {
+  const admin = { auth: { username: 'alice' } }
+
+  beforeEach(log.clear)
+
+  test('system metrics are not collected by default', async () => {
+    const { status } = await GET('/odata/v4/admin/Books', admin)
+    expect(status).to.equal(200)
+    
+    await wait(100)
+
+    expect(log.output).to.match(/process/i)
+    expect(log.output).not.to.match(/network/i)
+  })
+})

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -2,7 +2,7 @@ const cds = require('@sap/cds')
 const { expect, GET, POST } = cds.test().in(__dirname + '/bookshop')
 const log = cds.test.log()
 
-describe('Integration tests cds with open telemetry', () => {
+describe('tracing', () => {
   const admin = { auth: { username: 'alice' } }
 
   beforeEach(log.clear)


### PR DESCRIPTION
supersedes https://github.com/cap-js/telemetry/pull/100

thanks @marcsst!