### PR TITLE
feat(metrics): temporalityPreference ??= DELTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Register span processor also if tracer provider is initialized by a different module
-- Support for _Pull Metric Exporter_
+- Support for so-called _Pull Metric Exporter_ (e.g., `@opentelemetry/exporter-prometheus`)
 
 ### Changed
 
 - By default, all `system.*` metrics collected by `@opentelemetry/host-metrics` are ignored
   + Disable change via environment variable `HOST_METRICS_RETAIN_SYSTEM=true`
+- Metric exporter's property `temporalityPreference` always gets defaulted to `DELTA`
+  + Was previously only done for kind `telemetry-to-dynatrace`
+  + Set custom value via `cds.env.requires.telemetry.metrics.exporter.config.temporalityPreference`
 
 ## Version 0.0.4 - 2024-02-09
 

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -27,7 +27,6 @@ function _getExporter() {
     if (!token)
       throw new Error(`Neither "${token_name}" nor deprecated "rest_apitoken.token" found in Dynatrace credentials`)
     metricsConfig.headers.authorization ??= `Api-Token ${token}`
-    metricsConfig.temporalityPreference ??= require('@opentelemetry/sdk-metrics').AggregationTemporality.DELTA
   }
 
   const clc = getCloudLoggingCredentials()
@@ -35,6 +34,9 @@ function _getExporter() {
     metricsConfig.url ??= clc.url
     metricsConfig.credentials ??= clc.credentials
   }
+
+  // default to DELTA
+  metricsConfig.temporalityPreference ??= require('@opentelemetry/sdk-metrics').AggregationTemporality.DELTA
 
   const exporter = new metricsExporterModule[metricsExporter.class](metricsConfig)
   LOG._debug && LOG.debug('Using metrics exporter:', exporter)

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -3,7 +3,13 @@ const LOG = cds.log('telemetry')
 
 const { metrics } = require('@opentelemetry/api')
 const { Resource } = require('@opentelemetry/resources')
-const { DropAggregation, MeterProvider, PeriodicExportingMetricReader, View } = require('@opentelemetry/sdk-metrics')
+const {
+  AggregationTemporality,
+  DropAggregation,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  View
+} = require('@opentelemetry/sdk-metrics')
 
 const { getDynatraceMetadata, getDynatraceCredentials, getCloudLoggingCredentials, _require } = require('../utils')
 
@@ -36,7 +42,7 @@ function _getExporter() {
   }
 
   // default to DELTA
-  metricsConfig.temporalityPreference ??= require('@opentelemetry/sdk-metrics').AggregationTemporality.DELTA
+  metricsConfig.temporalityPreference ??= AggregationTemporality.DELTA
 
   const exporter = new metricsExporterModule[metricsExporter.class](metricsConfig)
   LOG._debug && LOG.debug('Using metrics exporter:', exporter)


### PR DESCRIPTION
after consultation with the experts, DELTA is a good default in general

- [x] changelog