### PR TITLE
fix(ConsoleSpanExporter): identify first-level spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   + Was previously only done for kind `telemetry-to-dynatrace`
   + Set custom value via `cds.env.requires.telemetry.metrics.exporter.config.temporalityPreference`
 
+### Fixed
+
+- Identification of first-level spans in built-in `ConsoleSpanExporter`
+
 ## Version 0.0.4 - 2024-02-09
 
 ### Added

--- a/lib/exporter/ConsoleSpanExporter.js
+++ b/lib/exporter/ConsoleSpanExporter.js
@@ -109,8 +109,8 @@ class ConsoleSpanExporter /* implements SpanExporter */ {
           const children = this._temporaryStorage.get(span.spanContext().traceId)
           if (children) {
             const batch = !!span.attributes['http.url']?.match(/\/\$batch/)
-            const ids = new Set(children.map(s => s.attributes.___id))
-            const reqs = children.filter(s => !ids.has(s.attributes.___parentId))
+            const ids = new Set(children.map(s => s.attributes.___id).filter(s => !!s))
+            const reqs = children.filter(s => s.attributes.___id && !ids.has(s.attributes.___parentId))
             const flat = []
             reqs.sort(_span_sorter)
             for (const each of reqs) {

--- a/lib/metrics/db-pool.js
+++ b/lib/metrics/db-pool.js
@@ -67,7 +67,7 @@ function init(pools) {
   })
 
   const max = meter.createObservableGauge('db.pool.max', {
-    description: 'The number of maxixmum number of resources allowed by pool',
+    description: 'The number of maximum number of resources allowed by pool',
     unit: 'each',
     valueType: ValueType.INT
   })


### PR DESCRIPTION
closes https://github.com/cap-js/telemetry/issues/109