### PR TITLE
fix: only throw in case of missing creds if respective kind is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- Validate existence of credentials only for configured kind
+
 ### Removed
 
 ## Version 0.1.0 - 2024-03-22

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -22,8 +22,9 @@ function _getExporter() {
     throw new Error(`Unknown metrics exporter "${metricsExporter.class}" in module "${metricsExporter.module}"`)
   const metricsConfig = { ...(metricsExporter.config || {}) }
 
-  const dynatrace = getDynatraceCredentials()
-  if (dynatrace && cds.env.requires.telemetry.kind.match(/dynatrace/)) {
+  if (cds.env.requires.telemetry.kind.match(/dynatrace/)) {
+    const dynatrace = getDynatraceCredentials()
+    if (!dynatrace) throw new Error('No Dynatrace credentials found.')
     metricsConfig.url ??= `${dynatrace.apiurl}/v2/otlp/v1/metrics`
     metricsConfig.headers ??= {}
     // dynatrace.rest_apitoken?.token is deprecated and only supported for compatibility reasons
@@ -35,8 +36,9 @@ function _getExporter() {
     metricsConfig.headers.authorization ??= `Api-Token ${token}`
   }
 
-  const clc = getCloudLoggingCredentials()
-  if (clc && cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
+  if (cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
+    const clc = getCloudLoggingCredentials()
+    if (!clc) throw new Error('No SAP Cloud Logging credentials found.')
     metricsConfig.url ??= clc.url
     metricsConfig.credentials ??= clc.credentials
   }

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -11,10 +11,15 @@ const {
   View
 } = require('@opentelemetry/sdk-metrics')
 
-const { getDynatraceMetadata, getDynatraceCredentials, getCloudLoggingCredentials, _require } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require } = require('../utils')
 
 function _getExporter() {
-  const metricsExporter = cds.env.requires.telemetry.metrics.exporter
+  let {
+    kind,
+    metrics: { exporter: metricsExporter },
+    credentials
+  } = cds.env.requires.telemetry
+
   // use _require for better error message
   const metricsExporterModule =
     metricsExporter.module === '@cap-js/telemetry' ? require('../exporter') : _require(metricsExporter.module)
@@ -22,25 +27,25 @@ function _getExporter() {
     throw new Error(`Unknown metrics exporter "${metricsExporter.class}" in module "${metricsExporter.module}"`)
   const metricsConfig = { ...(metricsExporter.config || {}) }
 
-  if (cds.env.requires.telemetry.kind.match(/dynatrace/)) {
-    const dynatrace = getDynatraceCredentials()
-    if (!dynatrace) throw new Error('No Dynatrace credentials found.')
-    metricsConfig.url ??= `${dynatrace.apiurl}/v2/otlp/v1/metrics`
+  if (kind.match(/dynatrace/)) {
+    if (!credentials) credentials = getCredsForDTAsUPS()
+    if (!credentials) throw new Error('No Dynatrace credentials found.')
+    metricsConfig.url ??= `${credentials.apiurl}/v2/otlp/v1/metrics`
     metricsConfig.headers ??= {}
-    // dynatrace.rest_apitoken?.token is deprecated and only supported for compatibility reasons
+    // credentials.rest_apitoken?.token is deprecated and only supported for compatibility reasons
     const { token_name } = cds.env.requires.telemetry
     // metrics_apitoken for compatibility with previous releases
-    const token = dynatrace[token_name] || dynatrace.metrics_apitoken || dynatrace.rest_apitoken?.token
+    const token = credentials[token_name] || credentials.metrics_apitoken || credentials.rest_apitoken?.token
     if (!token)
       throw new Error(`Neither "${token_name}" nor deprecated "rest_apitoken.token" found in Dynatrace credentials`)
     metricsConfig.headers.authorization ??= `Api-Token ${token}`
   }
 
-  if (cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
-    const clc = getCloudLoggingCredentials()
-    if (!clc) throw new Error('No SAP Cloud Logging credentials found.')
-    metricsConfig.url ??= clc.url
-    metricsConfig.credentials ??= clc.credentials
+  if (kind.match(/cloud-logging/)) {
+    if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
+    augmentCLCreds(credentials)
+    metricsConfig.url ??= credentials.url
+    metricsConfig.credentials ??= credentials.credentials
   }
 
   // default to DELTA

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -7,7 +7,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation')
 const { BatchSpanProcessor, SimpleSpanProcessor, SamplingDecision } = require('@opentelemetry/sdk-trace-base')
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node')
 
-const { getDynatraceMetadata, getDynatraceCredentials, getCloudLoggingCredentials, _require } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require } = require('../utils')
 
 function _getSampler() {
   const { ignoreIncomingPaths } = cds.env.requires.telemetry.instrumentations?.http?.config || {}
@@ -74,7 +74,12 @@ function _getInstrumentations() {
 }
 
 function _getExporter() {
-  const tracingExporter = cds.env.requires.telemetry.tracing.exporter
+  let {
+    kind,
+    tracing: { exporter: tracingExporter },
+    credentials
+  } = cds.env.requires.telemetry
+
   // use _require for better error message
   const tracingExporterModule =
     tracingExporter.module === '@cap-js/telemetry' ? require('../exporter') : _require(tracingExporter.module)
@@ -82,24 +87,24 @@ function _getExporter() {
     throw new Error(`Unknown tracing exporter "${tracingExporter.class}" in module "${tracingExporter.module}"`)
   const tracingConfig = { ...(tracingExporter.config || {}) }
 
-  if (cds.env.requires.telemetry.kind.match(/dynatrace/)) {
-    const dynatrace = getDynatraceCredentials()
-    if (!dynatrace) throw new Error('No Dynatrace credentials found.')
-    tracingConfig.url ??= `${dynatrace.apiurl}/v2/otlp/v1/traces`
+  if (kind.match(/dynatrace/)) {
+    if (!credentials) credentials = getCredsForDTAsUPS()
+    if (!credentials) throw new Error('No Dynatrace credentials found')
+    tracingConfig.url ??= `${credentials.apiurl}/v2/otlp/v1/traces`
     tracingConfig.headers ??= {}
-    // dynatrace.rest_apitoken?.token is deprecated and only supported for compatibility reasons
+    // credentials.rest_apitoken?.token is deprecated and only supported for compatibility reasons
     const { token_name } = cds.env.requires.telemetry
-    const token = dynatrace[token_name] || dynatrace.rest_apitoken?.token
+    const token = credentials[token_name] || credentials.rest_apitoken?.token
     if (!token)
       throw new Error(`Neither "${token_name}" nor deprecated "rest_apitoken.token" found in Dynatrace credentials`)
     tracingConfig.headers.authorization ??= `Api-Token ${token}`
   }
 
-  if (cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
-    const clc = getCloudLoggingCredentials()
-    if (!clc) throw new Error('No SAP Cloud Logging credentials found.')
-    tracingConfig.url ??= clc.url
-    tracingConfig.credentials ??= clc.credentials
+  if (kind.match(/cloud-logging/)) {
+    if (!credentials) throw new Error('No SAP Cloud Logging credentials found')
+    augmentCLCreds(credentials)
+    tracingConfig.url ??= credentials.url
+    tracingConfig.credentials ??= credentials.credentials
   }
 
   const exporter = new tracingExporterModule[tracingExporter.class](tracingConfig)

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -82,8 +82,9 @@ function _getExporter() {
     throw new Error(`Unknown tracing exporter "${tracingExporter.class}" in module "${tracingExporter.module}"`)
   const tracingConfig = { ...(tracingExporter.config || {}) }
 
-  const dynatrace = getDynatraceCredentials()
-  if (dynatrace && cds.env.requires.telemetry.kind.match(/dynatrace/)) {
+  if (cds.env.requires.telemetry.kind.match(/dynatrace/)) {
+    const dynatrace = getDynatraceCredentials()
+    if (!dynatrace) throw new Error('No Dynatrace credentials found.')
     tracingConfig.url ??= `${dynatrace.apiurl}/v2/otlp/v1/traces`
     tracingConfig.headers ??= {}
     // dynatrace.rest_apitoken?.token is deprecated and only supported for compatibility reasons
@@ -94,8 +95,9 @@ function _getExporter() {
     tracingConfig.headers.authorization ??= `Api-Token ${token}`
   }
 
-  const clc = getCloudLoggingCredentials()
-  if (clc && cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
+  if (cds.env.requires.telemetry.kind.match(/cloud-logging/)) {
+    const clc = getCloudLoggingCredentials()
+    if (!clc) throw new Error('No SAP Cloud Logging credentials found.')
     tracingConfig.url ??= clc.url
     tracingConfig.credentials ??= clc.credentials
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,34 +87,31 @@ function getDynatraceMetadata() {
   return dtmetadata
 }
 
-function getDynatraceCredentials() {
+function getCredsForDTAsUPS() {
   if (!process.env.VCAP_SERVICES) return
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
-  if (vcap.dynatrace?.[0]?.credentials) return vcap.dynatrace?.[0]?.credentials
+
   // to support connection via user-provided services, APMs requirement is that the instance name contains "dynatrace"
   if (vcap['user-provided']?.some(b => b.name.match(/dynatrace/)))
     return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
 }
 
-function getCloudLoggingCredentials() {
-  const cloud_logging =
-    process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES)['cloud-logging']?.[0]?.credentials
-  if (cloud_logging) {
-    if (!cloud_logging['ingest-otlp-endpoint']) {
-      throw new Error(
-        'No OpenTelemetry credentials found in SAP Cloud Logging binding. Create instance with config: "{ ingest_otlp: { enabled: true } }".'
-      )
-    }
-    const grpc = _require('@grpc/grpc-js')
-    const secureContext = require('tls').createSecureContext({
-      cert: cloud_logging['ingest-otlp-cert'],
-      key: cloud_logging['ingest-otlp-key']
-    })
-    return {
-      url: 'https://' + cloud_logging['ingest-otlp-endpoint'],
-      credentials: grpc.credentials.createFromSecureContext(secureContext)
-    }
-  }
+function augmentCLCreds(credentials) {
+  if (credentials._augmented) return
+  credentials._augmented = true
+
+  // prettier-ignore
+  if (!credentials['ingest-otlp-endpoint'])
+    throw new Error('No OpenTelemetry credentials found in binding to SAP Cloud Logging. Make sure to create the service instance with config: "{ ingest_otlp: { enabled: true } }".')
+
+  credentials.url = 'https://' + credentials['ingest-otlp-endpoint']
+
+  const grpc = _require('@grpc/grpc-js')
+  const secureContext = require('tls').createSecureContext({
+    cert: credentials['ingest-otlp-cert'],
+    key: credentials['ingest-otlp-key']
+  })
+  credentials.credentials = grpc.credentials.createFromSecureContext(secureContext)
 }
 
 let PKG
@@ -162,8 +159,8 @@ module.exports = {
   getDiagLogLevel,
   getResource,
   getDynatraceMetadata,
-  getDynatraceCredentials,
-  getCloudLoggingCredentials,
+  getCredsForDTAsUPS,
+  augmentCLCreds,
   hasDependency,
   _hrnow,
   _require

--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
           }
         },
         "telemetry-to-dynatrace": {
+          "vcap": {
+            "label": "dynatrace"
+          },
           "tracing": {
             "exporter": {
               "module": "@opentelemetry/exporter-trace-otlp-proto",
@@ -114,6 +117,9 @@
           "token_name": "ingest_apitoken"
         },
         "telemetry-to-cloud-logging": {
+          "vcap": {
+            "label": "cloud-logging"
+          },
           "tracing": {
             "exporter": {
               "module": "@opentelemetry/exporter-trace-otlp-grpc",

--- a/test/bookshop/_default-env.json
+++ b/test/bookshop/_default-env.json
@@ -1,0 +1,75 @@
+{
+  "VCAP_SERVICES": {
+    "dynatrace": [
+      {
+        "label": "dynatrace",
+        "provider": null,
+        "plan": "environment",
+        "name": "dummy",
+        "tags": ["dynatrace"],
+        "instance_guid": "00000000-0000-0000-0000-000000000000",
+        "instance_name": "dummy",
+        "binding_guid": "00000000-0000-0000-0000-000000000000",
+        "binding_name": null,
+        "credentials": {
+          "apitoken": "dummy",
+          "apiurl": "https://example.com",
+          "environmentid": "00000000-0000-0000-0000-000000000000",
+          "ingest_apitoken": "dummy",
+          "permission_assignments": [],
+          "skiperrors": "true",
+          "token_expiry": "9999-12-31T23:59:59.999Z"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "cloud-logging": [
+      {
+        "label": "cloud-logging",
+        "provider": null,
+        "plan": "standard",
+        "name": "dummy",
+        "tags": ["Cloud Logging"],
+        "instance_guid": "00000000-0000-0000-0000-000000000000",
+        "instance_name": "dummy",
+        "binding_guid": "00000000-0000-0000-0000-000000000000",
+        "binding_name": null,
+        "credentials": {
+          "client-ca": "-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n",
+          "dashboards-endpoint": "example.com",
+          "dashboards-password": "dummy",
+          "dashboards-username": "dummy",
+          "ingest-endpoint": "example.com",
+          "ingest-mtls-cert": "-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n",
+          "ingest-mtls-endpoint": "example.com",
+          "ingest-mtls-key": "-----BEGIN PRIVATE KEY-----\nDUMMY\n-----END PRIVATE KEY-----\n",
+          "ingest-otlp-cert": "-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n",
+          "ingest-otlp-endpoint": "example.com",
+          "ingest-otlp-key": "-----BEGIN PRIVATE KEY-----\nDUMMY\n-----END PRIVATE KEY-----\n",
+          "ingest-password": "dummy",
+          "ingest-username": "dummy",
+          "server-ca": "-----BEGIN CERTIFICATE-----\nDUMMY\n-----END CERTIFICATE-----\n"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "user-provided": [
+      {
+        "label": "user-provided",
+        "name": "any-string-including-dynatrace",
+        "tags": [],
+        "instance_guid": "00000000-0000-0000-0000-000000000000",
+        "instance_name": "dummy",
+        "binding_guid": "00000000-0000-0000-0000-000000000000",
+        "binding_name": null,
+        "credentials": {
+          "foo": "bar"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
closes https://github.com/cap-js/telemetry/issues/131

- [x] changelog entry
- [x] ensure setting via `cds.env` is also possible -> get and validate should probably be two separate steps