### PR TITLE
fix: detect build job started via `@sap/cds-dk/bin/cds.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.2.2 - tbd
+
+### Fixed
+
+- Detect build job triggered using `@sap/cds-dk/bin/cds.js`
+
 ## Version 0.2.1 - 2024-05-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Detect build job triggered using `@sap/cds-dk/bin/cds.js`
+- Detect build job started via `@sap/cds-dk/bin/cds.js`
 
 ## Version 0.2.1 - 2024-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.2.2 - tbd
+## Version 0.2.2 - 2024-06-03
 
 ### Fixed
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ module.exports = function () {
   // REVISIT: better
   // no need to fire up plugin during build (avoid credentials validation)
   const i = process.argv.indexOf('build')
-  if (i > 1 && process.argv[i - 1].endsWith('cds')) return
+  if (i > 1 && process.argv[i - 1].match(/cds(\.js)?$/)) return
 
   // set logger and propagate log level
   diag.setLogger(cds.log('telemetry'), process.env.OTEL_LOG_LEVEL || getDiagLogLevel())

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@opentelemetry/semantic-conventions": "^1.10.1"
   },
   "peerDependencies": {
-    "@sap/cds": ">=7 || ^8.0.0-beta"
+    "@sap/cds": ">=7"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/telemetry",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CDS plugin providing observability features, incl. automatic OpenTelemetry instrumentation.",
   "repository": "cap-js/telemetry",
   "author": "SAP SE (https://www.sap.com)",


### PR DESCRIPTION
closes https://github.com/cap-js/telemetry/issues/177