### PR TITLE
Add option to disable one agent

### DIFF
--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -130,7 +130,7 @@ module.exports = resource => {
     LOG._warn && LOG.warn('TracerProvider already initialized by a different module. It will be used as is.')
     tracerProvider = tracerProvider.getDelegate()
   }
-  if (process.env.DT_NODE_PRELOAD_OPTIONS && cds.env.requires.telemetry.kind.match(/dynatrace/)) {
+  if (!cds.env.requires.telemetry.disableOneAgent && process.env.DT_NODE_PRELOAD_OPTIONS && cds.env.requires.telemetry.kind.match(/dynatrace/)) {
     // if Dynatrace OneAgent is present, no exporter is needed
     LOG._info && LOG.info('Dynatrace OneAgent detected, disabling tracing exporter')
   } else {


### PR DESCRIPTION
The Dynatrace OneAgent currently doesn't transfer traces that are not initiated by an HTTP request (background traces). However, using the OpenTelemetry OTLP exporter works for this purpose. Therefore, we need the option to disable the OneAgent.