### PR TITLE
feat: SAP Cloud Logging as user provided service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Support for SAP Cloud Logging credentials via user-provided service
+
 ### Changed
 
 ### Fixed

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -11,7 +11,7 @@ const {
   View
 } = require('@opentelemetry/sdk-metrics')
 
-const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require, getCredsForCLSAsUPS } = require('../utils')
 
 function _getExporter() {
   let {
@@ -42,6 +42,7 @@ function _getExporter() {
   }
 
   if (kind.match(/cloud-logging/)) {
+    if (!credentials) credentials = getCredsForCLSAsUPS()
     if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
     augmentCLCreds(credentials)
     metricsConfig.url ??= credentials.url

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -11,7 +11,7 @@ const {
   View
 } = require('@opentelemetry/sdk-metrics')
 
-const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require, getCredsForCLSAsUPS } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, getCredsForCLSAsUPS, augmentCLCreds, _require } = require('../utils')
 
 function _getExporter() {
   let {

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -7,7 +7,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation')
 const { BatchSpanProcessor, SimpleSpanProcessor, SamplingDecision } = require('@opentelemetry/sdk-trace-base')
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node')
 
-const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require, getCredsForCLSAsUPS } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, getCredsForCLSAsUPS, augmentCLCreds, _require } = require('../utils')
 
 function _getSampler() {
   const { ignoreIncomingPaths } = cds.env.requires.telemetry.instrumentations?.http?.config || {}

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -7,7 +7,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation')
 const { BatchSpanProcessor, SimpleSpanProcessor, SamplingDecision } = require('@opentelemetry/sdk-trace-base')
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node')
 
-const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require } = require('../utils')
+const { getDynatraceMetadata, getCredsForDTAsUPS, augmentCLCreds, _require, getCredsForCLSAsUPS } = require('../utils')
 
 function _getSampler() {
   const { ignoreIncomingPaths } = cds.env.requires.telemetry.instrumentations?.http?.config || {}
@@ -101,6 +101,7 @@ function _getExporter() {
   }
 
   if (kind.match(/cloud-logging/)) {
+    if (!credentials) credentials = getCredsForCLSAsUPS()
     if (!credentials) throw new Error('No SAP Cloud Logging credentials found')
     augmentCLCreds(credentials)
     tracingConfig.url ??= credentials.url

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,6 +96,15 @@ function getCredsForDTAsUPS() {
     return vcap['user-provided'].find(b => b.name.match(/dynatrace/)).credentials
 }
 
+function getCredsForCLSAsUPS() {
+  if (!process.env.VCAP_SERVICES) return
+  const vcap = JSON.parse(process.env.VCAP_SERVICES)
+
+  // to support connection via user-provided services, APMs requirement is that the instance name contains "cloud-logging"
+  if (vcap['user-provided']?.some(b => b.name.match(/cloud-logging/)))
+    return vcap['user-provided'].find(b => b.name.match(/cloud-logging/)).credentials
+}
+
 function augmentCLCreds(credentials) {
   if (credentials._augmented) return
   credentials._augmented = true
@@ -160,6 +169,7 @@ module.exports = {
   getResource,
   getDynatraceMetadata,
   getCredsForDTAsUPS,
+  getCredsForCLSAsUPS,
   augmentCLCreds,
   hasDependency,
   _hrnow,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,7 +100,7 @@ function getCredsForCLSAsUPS() {
   if (!process.env.VCAP_SERVICES) return
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
 
-  // to support connection via user-provided services, APMs requirement is that the instance name contains "cloud-logging"
+  // to support connection via user-provided services, the instance name must contain "cloud-logging"
   if (vcap['user-provided']?.some(b => b.name.match(/cloud-logging/)))
     return vcap['user-provided'].find(b => b.name.match(/cloud-logging/)).credentials
 }


### PR DESCRIPTION
The plugin currently does not support UPS for Cloud Logging. This is described in the documentation:

https://help.sap.com/docs/cloud-logging/cloud-logging/ingest-via-cloud-foundry-runtime?locale=en-US&version=Cloud#procedures

UPS for Cloud Logging is enabled with this extension.