### PR TITLE
fix: adjust attribute name to process.cpu.state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- Built-in `ConsoleMetricExporter` uses correct attribute name `process.cpu.state` while exporting host metrics
+
 ## Version 1.0.1 - 2024-08-10
 
 ### Fixed

--- a/lib/exporter/ConsoleMetricExporter.js
+++ b/lib/exporter/ConsoleMetricExporter.js
@@ -42,7 +42,7 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
           }
           if (name === 'process.cpu.time' || name === 'process.cpu.utilization') {
             collector[name] ??= {}
-            for (const dp of metric.dataPoints) collector[name][dp.attributes.state] = dp.value
+            for (const dp of metric.dataPoints) collector[name][dp.attributes['process.cpu.state']] = dp.value
           }
           if (metric.descriptor.name === 'process.memory.usage') {
             collector[name] = metric.dataPoints[0].value


### PR DESCRIPTION
closes https://github.com/cap-js/telemetry/issues/222