### PR TITLE
Enable trace handlers via env

### DIFF
--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -54,7 +54,7 @@ module.exports = () => {
 
   cds.on('serving', service => {
     // trace individual event handlers -> INOFFICIAL!
-    if ((cds.env.requires.telemetry.tracing?.level === 'debug' && process.env.CDS_TRACE_HANDLERS === undefined) || (!!process.env.CDS_TRACE_HANDLERS && process.env.CDS_TRACE_HANDLERS !== 'false')) {
+    if ((cds.env.requires.telemetry.tracing?.level === 'debug' && process.env.CDS_TRACE_HANDLERS === undefined) || (!!process.env.CDS_TRACE_HANDLERS && process.env.CDS_TRACE_HANDLERS !== 'false')) {
       for (const each of ['_error', '_initial', 'on', 'before', 'after']) {
         service._handlers[each].forEach(_wrapHandler)
       }

--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -54,7 +54,7 @@ module.exports = () => {
 
   cds.on('serving', service => {
     // trace individual event handlers -> INOFFICIAL!
-    if (cds.env.requires.telemetry.tracing?.level === 'debug' || (!!process.env.CDS_TRACE_HANDLERS && process.env.CDS_TRACE_HANDLERS !== 'false')) {
+    if ((cds.env.requires.telemetry.tracing?.level === 'debug' && process.env.CDS_TRACE_HANDLERS === undefined) || (!!process.env.CDS_TRACE_HANDLERS && process.env.CDS_TRACE_HANDLERS !== 'false')) {
       for (const each of ['_error', '_initial', 'on', 'before', 'after']) {
         service._handlers[each].forEach(_wrapHandler)
       }

--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -54,7 +54,7 @@ module.exports = () => {
 
   cds.on('serving', service => {
     // trace individual event handlers -> INOFFICIAL!
-    if (cds.env.requires.telemetry.tracing?.level === 'debug') {
+    if (cds.env.requires.telemetry.tracing?.level === 'debug' || (!!process.env.CDS_TRACE_HANDLERS && process.env.CDS_TRACE_HANDLERS !== 'false')) {
       for (const each of ['_error', '_initial', 'on', 'before', 'after']) {
         service._handlers[each].forEach(_wrapHandler)
       }


### PR DESCRIPTION
Allows to toggle handler tracing also via an env variable. 
Use case: enable handler tracing on dev environment but not on prod to analyse where the performance goes.