### PR TITLE
feat: db.client.response.returned_rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.2.0 - tbd
+
+### Added
+
+- Trace attribute `db.client.response.returned_rows` for queries via `cds.ql`
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## Version 1.1.2 - 2024-12-10
 
 ### Fixed

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -185,7 +185,8 @@ function _setAttributes(span, attributes) {
 }
 
 const _addDbRowCount = (span, res) => {
-  if (!span.attributes['db.statement'] || !['all', 'run'].includes(span.attributes['code.function'])) return
+  if (!span.attributes['db.statement']) return
+  if (!['all', 'run'].includes(span.attributes['code.function'])) return
 
   let rowCount
   switch (span.attributes['db.operation']) {

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -58,8 +58,7 @@ function _getParentSpan() {
       // root span gets request attributes
       _setAttributes(parent, _getRequestAttributes())
       if (HRTIME) parent.startTime = cds.context.http?.req?.__hrnow || _hrnow()
-      if (ADJUST_ROOT_NAME && parent.attributes[ATTR_URL_PATH])
-        parent.name += ' ' + parent.attributes[ATTR_URL_PATH]
+      if (ADJUST_ROOT_NAME && parent.attributes[ATTR_URL_PATH]) parent.name += ' ' + parent.attributes[ATTR_URL_PATH]
     }
     if (!parent?._is_async) cds.context._otelctx.setValue(cds.context._otelKey, parent)
   }
@@ -185,6 +184,22 @@ function _setAttributes(span, attributes) {
   attributes.forEach((value, key) => span.setAttribute(key, value))
 }
 
+const _addDbRowCount = (span, res) => {
+  if (!span.attributes['db.statement'] || !['all', 'run'].includes(span.attributes['code.function'])) return
+
+  let rowCount
+  switch (span.attributes['db.operation']) {
+    case 'DELETE':
+    case 'UPDATE':
+    case 'CREATE':
+      rowCount = res.changes
+      break
+    case 'READ':
+      rowCount = res.length ?? 1
+  }
+  if (rowCount != null) span.setAttribute('db.client.response.returned_rows', rowCount)
+}
+
 function trace(name, fn, targetObj, args, options = {}) {
   // REVISIT: only start tracing once served
   if (!cds._telemetry.tracer._active) return fn.apply(targetObj, args)
@@ -292,6 +307,7 @@ function trace(name, fn, targetObj, args, options = {}) {
    */
   return otel.context.with(cds.context?._otelctx.setValue(cds.context._otelKey, span), () => {
     const onSuccess = res => {
+      _addDbRowCount(span, res)
       span.setStatus({ code: SpanStatusCode.OK })
       return res
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/telemetry",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "CDS plugin providing observability features, incl. automatic OpenTelemetry instrumentation.",
   "repository": {
     "type": "git",

--- a/test/tracing-attributes.test.js
+++ b/test/tracing-attributes.test.js
@@ -1,0 +1,38 @@
+process.env.cds_requires_telemetry_tracing_exporter_module = '@opentelemetry/sdk-trace-node'
+
+const cds = require('@sap/cds')
+const { expect, data } = cds.test().in(__dirname + '/bookshop')
+
+describe('tracing attributes', () => {
+  beforeEach(data.reset)
+
+  const log = jest.spyOn(console, 'dir')
+  beforeEach(log.mockClear)
+
+  describe('db.client.response.returned_rows', () => {
+    test('SELECT', async () => {
+      await SELECT.from('sap.capire.bookshop.Books')
+      const output = JSON.stringify(log.mock.calls)
+      expect(output).to.match(/db\.client\.response.returned_rows":5/)
+    })
+
+    test('INSERT', async () => {
+      await INSERT.into('sap.capire.bookshop.Books').entries([{ ID: 1 }, { ID: 2 }])
+      const output = JSON.stringify(log.mock.calls)
+      expect(output).to.match(/db\.client\.response.returned_rows":2/)
+    })
+
+    test('UPDATE', async () => {
+      await UPDATE('sap.capire.bookshop.Books').set({ stock: 42 }).where('ID > 250')
+      const output = JSON.stringify(log.mock.calls)
+      expect(output).to.match(/db\.client\.response.returned_rows":3/)
+    })
+
+    test('DELETE', async () => {
+      await DELETE.from('sap.capire.bookshop.Books')
+      const output = JSON.stringify(log.mock.calls)
+      expect(output).to.match(/db\.client\.response.returned_rows":0/) //> texts
+      expect(output).to.match(/db\.client\.response.returned_rows":5/)
+    })
+  })
+})


### PR DESCRIPTION
non-fork version of https://github.com/cap-js/telemetry/pull/271

- [x] tests
- [x] changelog entry