### PR TITLE
fix: Keep SAP Passport up-to-date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Improved support for tracing messaging services and `cds.spawn`
 - Support for adding custom spans to trace hierarchy via `tracer.startActiveSpan()` (beta)
 - Trace attribute `db.client.response.returned_rows` for queries via `cds.ql`
+- Experimental!: Trace HANA interaction via `@cap-js/hana`'s promisification of the driver API for increased accuracy
+  - Enable via config `cds.env.requires.telemetry.tracing._hana_prom`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Trace attribute `db.client.response.returned_rows` for queries via `cds.ql`
 - Experimental!: Trace HANA interaction via `@cap-js/hana`'s promisification of the driver API for increased accuracy
   - Enable via config `cds.env.requires.telemetry.tracing._hana_prom`
+  - Requires `@cap-js/hana^1.7.0`
 
 ### Changed
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,8 @@ function _getInstrumentations() {
           module: '@opentelemetry/instrumentation-runtime-node'
         }
       }
-    } catch (e) {
-      LOG._debug && LOG.debug('Failed to automatically add @opentelemetry/instrumentation-runtime-node:', e)
+    } catch (err) {
+      LOG._debug && LOG.debug('Failed to automatically add @opentelemetry/instrumentation-runtime-node:', err)
     }
   }
 

--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -18,7 +18,7 @@ const _wrapStmt = (stmt, impl, sql) => {
     stmt[fn] = wrap(it, {
       no_locate: true,
       wrapper: function () {
-        return trace(`${impl} - stmt.${fn} ${sql}`, it, this, arguments, { sql, fn })
+        return trace(`${impl} - stmt.${fn} ${sql}`, it, this, arguments, { sql, fn, outbound: true })
       }
     })
   }
@@ -63,12 +63,12 @@ module.exports = () => {
 
   const impl = cds.env.requires.db?.impl
   if (impl?.match(/^@cap-js\//)) {
-    const dbService = require(impl)
     cds.once('served', () => {
+      const dbService = cds.db.constructor
       const { prepare: _prepare, exec: _exec } = dbService.prototype
       dbService.prototype.prepare = wrap(_prepare, {
         wrapper: function prepare(sql) {
-          const stmt = trace(`${impl} - prepare ${sql}`, _prepare, this, arguments, { sql, fn: 'prepare' })
+          const stmt = trace(`${impl} - prepare ${sql}`, _prepare, this, arguments, { sql, fn: 'prepare', outbound: true })
           if (stmt instanceof Promise) return stmt.then(stmt => _wrapStmt(stmt, impl, sql))
           return _wrapStmt(stmt, impl, sql)
         }
@@ -77,9 +77,23 @@ module.exports = () => {
         wrapper: function exec(sql) {
           if (!cds.env.requires.telemetry.tracing._tx && sql in { BEGIN: 1, COMMIT: 1, ROLLBACK: 1 })
             return _exec.apply(this, arguments)
-          return trace(`${impl} - exec ${sql}`, _exec, this, arguments, { sql, fn: 'exec' })
+          return trace(`${impl} - exec ${sql}`, _exec, this, arguments, { sql, fn: 'exec', outbound: true })
         }
       })
+
+      if (impl === '@cap-js/hana') {
+        // REVISIT: when telemetry and hana are loaded from differen places this doesn't work
+        const hanaDriver = require('@cap-js/hana/lib/drivers/base.js')
+        const _prom = hanaDriver.prom
+        hanaDriver.prom = function (dbc, func) {
+          const fn = _prom(dbc, func)
+          dbc = dbc._parentConnection || dbc
+          const driver = dbc.constructor.name === 'Client' ? 'hdb' : '@sap/hana-client'
+          return function prom() {
+            return trace(`${driver} - ${func}`, fn, this, arguments, { dbc, fn: func, outbound: true })
+          }
+        }
+      }
     })
   }
 }

--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -82,7 +82,7 @@ module.exports = () => {
   if (impl?.match(/^@cap-js\//)) {
     cds.once('served', () => {
       // HANA
-      if (impl === '@cap-js/hana' && cds.env.requires.telemetry.tracing._wrap_hana_prom) {
+      if (impl === '@cap-js/hana' && cds.env.requires.telemetry.tracing._hana_prom) {
         try {
           const [major, minor] = require('@cap-js/hana/package.json').version.split('.')
           if (major > 1 || (major === 1 && minor >= 7)) {

--- a/lib/tracing/cds.js
+++ b/lib/tracing/cds.js
@@ -1,4 +1,5 @@
 const cds = require('@sap/cds')
+const LOG = cds.log('telemetry')
 
 const { SpanKind } = require('@opentelemetry/api')
 
@@ -80,6 +81,30 @@ module.exports = () => {
   const impl = cds.env.requires.db?.impl
   if (impl?.match(/^@cap-js\//)) {
     cds.once('served', () => {
+      // HANA
+      if (impl === '@cap-js/hana' && cds.env.requires.telemetry.tracing._wrap_hana_prom) {
+        try {
+          const [major, minor] = require('@cap-js/hana/package.json').version.split('.')
+          if (major > 1 || (major === 1 && minor >= 7)) {
+            // REVISIT: when telemetry and hana are loaded from differen places this doesn't work
+            const hanaDriver = require('@cap-js/hana/lib/drivers/base.js')
+            const _prom = hanaDriver.prom
+            hanaDriver.prom = function (dbc, func) {
+              const fn = _prom(dbc, func)
+              dbc = dbc._parentConnection || dbc
+              const driver = dbc.constructor.name === 'Client' ? 'hdb' : '@sap/hana-client'
+              return function prom() {
+                return trace(`${driver} - ${func}`, fn, this, arguments, { dbc, fn: func, kind: SpanKind.CLIENT })
+              }
+            }
+            return
+          }
+        } catch (err) {
+          LOG._warning && LOG.warning('Failed to wrap hana driver due to error:', err)
+        }
+      }
+
+      // other DBs
       const dbService = cds.db.constructor
       const { prepare: _prepare, exec: _exec } = dbService.prototype
       dbService.prototype.prepare = wrap(_prepare, {
@@ -100,20 +125,6 @@ module.exports = () => {
           return trace(`${impl} - exec ${sql}`, _exec, this, arguments, { sql, fn: 'exec', kind: SpanKind.CLIENT })
         }
       })
-
-      if (impl === '@cap-js/hana') {
-        // REVISIT: when telemetry and hana are loaded from differen places this doesn't work
-        const hanaDriver = require('@cap-js/hana/lib/drivers/base.js')
-        const _prom = hanaDriver.prom
-        hanaDriver.prom = function (dbc, func) {
-          const fn = _prom(dbc, func)
-          dbc = dbc._parentConnection || dbc
-          const driver = dbc.constructor.name === 'Client' ? 'hdb' : '@sap/hana-client'
-          return function prom() {
-            return trace(`${driver} - ${func}`, fn, this, arguments, { dbc, fn: func, outbound: true })
-          }
-        }
-      }
     })
   }
 }

--- a/lib/tracing/okra.js
+++ b/lib/tracing/okra.js
@@ -8,8 +8,8 @@ module.exports = () => {
   let OKRAService
   try {
     OKRAService = require('@sap/cds/libx/_runtime/cds-services/adapter/odata-v4/okra/odata-server/core/Service')
-  } catch (e) {
-    LOG._warn && LOG.warn('Unable to instrument Okra due to error:', e)
+  } catch (err) {
+    LOG._warn && LOG.warn('Unable to instrument Okra due to error:', err)
     return
   }
 

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -87,7 +87,7 @@ function _getSpanName(arg, fn, targetObj) {
 
 function _determineKind(targetObj, phase, isAsyncConsumer, options) {
   // DB Calls & Remote calls are client calls
-  if (targetObj.dbc || targetObj.constructor.name === 'RemoteService' || options.outbound) return SpanKind.CLIENT
+  if (targetObj.constructor.name === 'RemoteService' || options.outbound) return SpanKind.CLIENT
   if (targetObj.constructor.name === 'cds' || phase === 'emit')
     // cds.spawn or srv.emit
     return SpanKind.PRODUCER
@@ -170,11 +170,11 @@ function _getDynamicDBAttributes(options, args, parentSpan) {
   //       the second time, args is the string query -> we need to get event and target from the previous invocation (i.e., parentSpan).
   const dbAttributes = new Map()
   const db_statement =
-    options.sql || (typeof args[0].query === 'string' && args[0].query) || (typeof args[0] === 'string' && args[0])
+    options.sql || (typeof args[0]?.query === 'string' && args[0].query) || (typeof args[0] === 'string' && args[0])
   if (db_statement) dbAttributes.set(ATTR_DB_STATEMENT, db_statement)
-  const db_operation = args[0].event || parentSpan?.attributes[ATTR_DB_OPERATION]
+  const db_operation = args[0]?.event || parentSpan?.attributes[ATTR_DB_OPERATION]
   if (db_operation) dbAttributes.set(ATTR_DB_OPERATION, db_operation)
-  const db_sql_table = args[0].target?.name || parentSpan?.attributes[ATTR_DB_SQL_TABLE]
+  const db_sql_table = args[0]?.target?.name || parentSpan?.attributes[ATTR_DB_SQL_TABLE]
   if (db_sql_table) dbAttributes.set(ATTR_DB_SQL_TABLE, db_sql_table)
   return dbAttributes
 }
@@ -254,33 +254,32 @@ function trace(name, fn, targetObj, args, options = {}) {
     _setAttributes(span, _getDynamicDBAttributes(options, args, parentSpan))
 
     // SAP Passport
-    if (process.env.SAP_PASSPORT && targetObj.dbc?.constructor.name in { HDBDriver: 1, HANAClientDriver: 1 }) {
+    if (process.env.SAP_PASSPORT && options.dbc?.set) {
       const { spanId, traceId } = span.spanContext()
+      // REVISIT: @sap/dsrpassport uses '0226' for VARPARTOFFSET
       // prettier-ignore
-      let passport = [
-        /* EYECATCHER      */ '2A54482A',
-        /* VERSION         */ '03',
-        /* LENGTH          */ '00E6',
-        /* TRACELEVEL      */ '0000',
-        /* COMPONENTID     */ '2020202020202020202020202020202020202020202020202020202020202020',
-        /* SERVICE         */ '0000',
-        /* USER            */ '2020202020202020202020202020202020202020202020202020202020202020',
-        /* ACTION          */ '20202020202020202020202020202020202020202020202020202020202020202020202020202020',
-        /* ACTIONTYPE      */ '0000',
-        /* PREVCOMPONENTID */ Buffer.from(span.resource.attributes['service.name'].substr(0, 32).padEnd(32, ' ')).toString('hex'),
-        /* TRANSACTIONID   */ Buffer.from(traceId.toUpperCase()).toString('hex'),
-        /* CLIENT          */ '202020',
-        /* COMPONENTTYPE   */ '0000',
-        /* ROOTCONTEXTID   */ traceId.toUpperCase(),
-        /* CONNECTIONID    */ '0000000000000001' + spanId.toUpperCase(),
-        /* CONNECTIONCNT   */ '00000001',
-        /* VARPARTCOUNT    */ '0000',
-        /* VARPARTOFFSET   */ '0000', // REVISIT: @sap/dsrpassport uses '0226'
-        /* EYECATCHER      */ '2A54482A'
-      ]
-      passport = passport.join('')
+      let passport = `${
+        /* EYECATCHER      */ '2A54482A'}${
+        /* VERSION         */ '03'}${
+        /* LENGTH          */ '00E6'}${
+        /* TRACELEVEL      */ '0000'}${
+        /* COMPONENTID     */ '2020202020202020202020202020202020202020202020202020202020202020'}${
+        /* SERVICE         */ '0000'}${
+        /* USER            */ '2020202020202020202020202020202020202020202020202020202020202020'}${
+        /* ACTION          */ '20202020202020202020202020202020202020202020202020202020202020202020202020202020'}${
+        /* ACTIONTYPE      */ '0000'}${
+        /* PREVCOMPONENTID */ Buffer.from(span.resource.attributes['service.name'].substr(0, 32).padEnd(32, ' ')).toString('hex')}${
+        /* TRANSACTIONID   */ Buffer.from(traceId.toUpperCase()).toString('hex')}${
+        /* CLIENT          */ '202020'}${
+        /* COMPONENTTYPE   */ '0000'}${
+        /* ROOTCONTEXTID   */ traceId.toUpperCase()}${
+        /* CONNECTIONID    */ '0000000000000001' + spanId.toUpperCase()}${
+        /* CONNECTIONCNT   */ '00000001'}${
+        /* VARPARTCOUNT    */ '0000'}${
+        /* VARPARTOFFSET   */ '0000' }${
+        /* EYECATCHER      */ '2A54482A'}`
       LOG._debug && LOG.debug('Setting SAP Passport:', passport)
-      targetObj.dbc.set({ SAP_PASSPORT: passport })
+      options.dbc.set({ SAP_PASSPORT: passport })
     }
 
     // augment db.statement at parent, if necessary

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -204,7 +204,7 @@ function _addAttributes(span, fn, that, options, args, parent) {
       const { spanId, traceId } = span.spanContext()
       // REVISIT: @sap/dsrpassport uses '0226' for VARPARTOFFSET
       // prettier-ignore
-      let passport = `${
+      const passport = `${
         /* EYECATCHER      */ '2A54482A'}${
         /* VERSION         */ '03'}${
         /* LENGTH          */ '00E6'}${

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,9 +162,9 @@ function _require(name) {
   name = Array.isArray(name) ? name[0] : name
   try {
     return require(name.startsWith('./') ? cds.utils.path.join(cds.root, name) : name)
-  } catch (e) {
-    e.message = `Cannot find module '${name}'. Make sure to install it with 'npm i ${name}'\n` + e.message
-    throw e
+  } catch (err) {
+    err.message = `Cannot find module '${name}'. Make sure to install it with 'npm i ${name}'\n` + err.message
+    throw err
   }
 }
 


### PR DESCRIPTION
Currently `SAP Passport` is only updated when `prepare` and `exec` are called, but it is required to update every time the database is called. Therefor this PR shifts the `SAP Passport` criteria to using `prom`. Which is the re use function `@cap-js/hana` uses inside its generic driver wrappers to promisify the native driver functions. Therefor by tracing the `prom` function it traces _all_* driver calls and ensures that the `SAP Passport` contains an unique trace ID which open telemetry can anchor itself onto. As without the round trip specific parent trace ID the open telemetry service provider will see the child trace timestamps outside of the parent trace window and try to adjust the timestamp into the parent trace time frame. Which gets especially confusing when the parent time frame is smaller then the child time frame.

![image](https://github.com/user-attachments/assets/e8a92aa3-7748-4089-a33e-eb2e99f05af6)

It still has to be investigated how well the `prom` wrapping approach works for the `resultset streaming` (https://github.com/cap-js/cds-dbs/pull/702) feature.