### PR TITLE
chore: cleanup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Predefined kind `telemetry-to-otlp` that creates exporters based on OTLP exporter configuration via environment variables
-- Experimental!: Propagate W3C trace context to SAP HANA via session context `SAP_PASSPORT`
-  - Enable via environment variable `SAP_PASSPORT`
 - If `@opentelemetry/instrumentation-runtime-node` is in the project's dependencies but not in `cds.requires.telemetry.instrumentations`, it is registered automatically
   - Disable via `cds.requires.telemetry.instrumentations.instrumentation-runtime-node = false`
+- Experimental!: Propagate W3C trace context to SAP HANA via session context `SAP_PASSPORT`
+  - Enable via environment variable `SAP_PASSPORT`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for adding custom spans to trace hierarchy via `tracer.startActiveSpan()` (beta)
 - Trace attribute `db.client.response.returned_rows` for queries via `cds.ql`
 - Experimental!: Trace HANA interaction via `@cap-js/hana`'s promisification of the driver API for increased accuracy
-  - Enable via config `cds.env.requires.telemetry.tracing._hana_prom`
+  - Enable via config `cds.requires.telemetry.tracing._hana_prom`
   - Requires `@cap-js/hana^1.7.0`
 
 ### Changed
@@ -42,8 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Predefined kind `telemetry-to-otlp` that creates exporters based on OTLP exporter configuration via environment variables
 - Experimental!: Propagate W3C trace context to SAP HANA via session context `SAP_PASSPORT`
   - Enable via environment variable `SAP_PASSPORT`
-- If `@opentelemetry/instrumentation-runtime-node` is in the project's dependencies but not in `cds.env.requires.telemetry.instrumentations`, it is registered automatically
-  - Disable via `cds.env.requires.telemetry.instrumentations.instrumentation-runtime-node = false`
+- If `@opentelemetry/instrumentation-runtime-node` is in the project's dependencies but not in `cds.requires.telemetry.instrumentations`, it is registered automatically
+  - Disable via `cds.requires.telemetry.instrumentations.instrumentation-runtime-node = false`
 
 ### Changed
 
@@ -108,7 +108,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Support for local modules (e.g., exporters) via `[...].module = '<path relative to cds.root>'`
-- Disable pool metrics via `cds.env.requires.telemetry.metrics._db_pool = false` (beta)
+- Disable pool metrics via `cds.requires.telemetry.metrics._db_pool = false` (beta)
 
 ### Fixed
 
@@ -121,7 +121,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Support for own, high resolution timestamps
-  - Enable via `cds.env.requires.telemetry.tracing.hrtime = true`
+  - Enable via `cds.requires.telemetry.tracing.hrtime = true`
   - Enabled by default in development profile
 
 ## Version 0.0.5 - 2024-03-11
@@ -138,7 +138,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   - Disable change via environment variable `HOST_METRICS_RETAIN_SYSTEM=true`
 - Metric exporter's property `temporalityPreference` always gets defaulted to `DELTA`
   - Was previously only done for kind `telemetry-to-dynatrace`
-  - Set custom value via `cds.env.requires.telemetry.metrics.exporter.config.temporalityPreference`
+  - Set custom value via `cds.requires.telemetry.metrics.exporter.config.temporalityPreference`
 
 ### Fixed
 


### PR DESCRIPTION
- `cds.env.requires` → `cds.requires`
- move experimental features to end of added