### PR TITLE
Prevent undefined/null value

### DIFF
--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -133,7 +133,7 @@ function _getRequestAttributes() {
     attributes.set(ATTR_HTTP_REQUEST_METHOD, req.method)
     for (const [key, value] of Object.entries(cds.context.http.req.headers || {})) {
       if (MASK_HEADERS.some(m => key.match(m))) attributes.set(`http.request.header.${key}`, '***')
-      else attributes.set(`http.request.header.${key}`, value.split(';'))
+      else attributes.set(`http.request.header.${key}`, value?.split(';') ?? '')
     }
 
     cds.context.http.req[$reqattrs] = attributes

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -133,7 +133,7 @@ function _getRequestAttributes() {
     attributes.set(ATTR_HTTP_REQUEST_METHOD, req.method)
     for (const [key, value] of Object.entries(cds.context.http.req.headers || {})) {
       if (MASK_HEADERS.some(m => key.match(m))) attributes.set(`http.request.header.${key}`, '***')
-      else attributes.set(`http.request.header.${key}`, value?.split(';') ?? '')
+      else attributes.set(`http.request.header.${key}`, value?.split(';') ?? 'undefined') //> there have been reports of undefined header values in production -> please keep!
     }
 
     cds.context.http.req[$reqattrs] = attributes


### PR DESCRIPTION
Add check on possible undefined / null value in order to prevent crash. 

Fixing crash:

`TypeError: Cannot read properties of undefined (reading 'split') at _getRequestAttributes (/home/vcap/deps/0/node_modules/.pnpm/@cap-js+telemetry@1.0.1_@sap+cds@7.9.3_express@4.21.2_/node_modules/@cap-js/telemetry/lib/tracing/trace.js:152:63) at _getParentSpan (/home/vcap/deps/0/node_modules/.pnpm/@cap-js+telemetry@1.0.1_@sap+cds@7.9.3_express@4.21.2_/node_modules/@cap-js/telemetry/lib/tracing/trace.js:57:30) at trace (/home/vcap/deps/0/node_modules/.pnpm/@cap-js+telemetry@1.0.1_@sap+cds@7.9.3_express@4.21.2_/node_modules/@cap-js/telemetry/lib/tracing/trace.js:203:22) at wrapper (/home/vcap/deps/0/node_modules/.pnpm/@cap-js+telemetry@1.0.1_@sap+cds@7.9.3_express@4.21.2_/node_modules/@cap-js/telemetry/lib/tracing/wrap.js:26:18) at /home/vcap/deps/0/node_modules/.pnpm/@sap+cds@7.9.3_express@4.21.2/node_modules/@sap/cds/lib/req/cds-context.js:39:32 at AsyncLocalStorage.run (node:async_hooks:346:14) at AsyncLocalStorage.run (/home/vcap/deps/0/node_modules/.pnpm/@sap+cds@7.9.3_express@4.21.2/node_modules/@sap/cds/lib/req/cds-context.js:7:36) at Immediate.fx (/home/vcap/deps/0/node_modules/.pnpm/@sap+cds@7.9.3_express@4.21.2/node_modules/@sap/cds/lib/req/cds-context.js:30:27) at process.processImmediate (node:internal/timers:483:21) at process.callbackTrampoline (node:internal/async_hooks:130:17)`