### PR TITLE
fix: add resilience to attributes handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Don't crash in case property `attributes` of parent span is undefined
+- Don't crash in case there are errors while determining the attributes for the current span
 
 ## Version 1.2.2 - 2025-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.2.3 - 2025-03-10
+
+### Fixed
+
+- Don't crash in case property `attributes` of parent span is undefined
+
 ## Version 1.2.2 - 2025-03-03
 
 ### Fixed

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -285,11 +285,12 @@ function trace(req, fn, that, args, opts = {}) {
 
   // REVISIT: improve attributes handling
   //          coding relies on setting attributes on the existing span, but now we create it later (cf. startActiveSpan)
-  const collector = {
-    attributes: options.attributes,
-    setAttribute: (k, v) => (options.attributes[k] = v)
+  try {
+    const collector = { attributes: options.attributes, setAttribute: (k, v) => (options.attributes[k] = v) }
+    _addAttributes(collector, fn, that, opts, args, parent)
+  } catch (err) {
+    LOG._warn && LOG.warn('Failed to set attributes:', err)
   }
-  _addAttributes(collector, fn, that, opts, args, parent)
 
   // start a new active span, call the original function, and finally end the span
   return tracer.startActiveSpan(name, options, span => {

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -289,7 +289,7 @@ function trace(req, fn, that, args, opts = {}) {
     const collector = { attributes: options.attributes, setAttribute: (k, v) => (options.attributes[k] = v) }
     _addAttributes(collector, fn, that, opts, args, parent)
   } catch (err) {
-    LOG._warn && LOG.warn('Failed to set attributes:', err)
+    LOG._warn && LOG.warn('Failed to determine attributes:', err)
   }
 
   // start a new active span, call the original function, and finally end the span

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/telemetry",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "CDS plugin providing observability features, incl. automatic OpenTelemetry instrumentation.",
   "repository": {
     "type": "git",

--- a/test/bookshop/server.js
+++ b/test/bookshop/server.js
@@ -2,7 +2,6 @@ const cds = require('@sap/cds')
 
 cds.on('bootstrap', app => {
   app.use('/custom/Books', async (req, res) => {
-    await cds.connect.to('db')
     const books = await SELECT.from('Books')
     res.json(books)
   })

--- a/test/bookshop/server.js
+++ b/test/bookshop/server.js
@@ -1,0 +1,9 @@
+const cds = require('@sap/cds')
+
+cds.on('bootstrap', app => {
+  app.use('/custom/Books', async (req, res) => {
+    await cds.connect.to('db')
+    const books = await SELECT.from('Books')
+    res.json(books)
+  })
+})

--- a/test/bookshop/test.http
+++ b/test/bookshop/test.http
@@ -69,3 +69,7 @@ Authorization: Basic alice:wonderland
 
 GET {{host}}/odata/v4/admin/Genres
 Authorization: Basic alice:wonderland
+
+###
+
+GET {{host}}/custom/Books

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -37,7 +37,7 @@ describe('tracing', () => {
     expect(status).to.equal(200)
     // primitive check that console has trace logs
     expect(log.output).to.match(/\[telemetry\] - elapsed times:/)
-    expect(log.output).to.match(/\s+\d+\.\d+ → \s*\d+\.\d+ = \s*\d+\.\d+ ms \s* AdminService - READ AdminService.Books/)
+    expect(log.output).to.match(/\s+\d+\.\d+ → \s*\d+\.\d+ = \s*\d+\.\d+ ms \s* db - READ sap.capire.bookshop.Books/)
   })
 
   test('NonRecordingSpans are handled correctly', async () => {

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -32,6 +32,14 @@ describe('tracing', () => {
     expect(log.output).to.match(/\s+\d+\.\d+ → \s*\d+\.\d+ = \s*\d+\.\d+ ms \s* AdminService - READ AdminService.Books/)
   })
 
+  test('custom GET is traced', async () => {
+    const { status } = await GET('/custom/Books', admin)
+    expect(status).to.equal(200)
+    // primitive check that console has trace logs
+    expect(log.output).to.match(/\[telemetry\] - elapsed times:/)
+    expect(log.output).to.match(/\s+\d+\.\d+ → \s*\d+\.\d+ = \s*\d+\.\d+ ms \s* AdminService - READ AdminService.Books/)
+  })
+
   test('NonRecordingSpans are handled correctly', async () => {
     const { status: postStatus } = await POST('/odata/v4/admin/Authors', { ID: 42, name: 'Douglas Adams' }, admin)
     expect(postStatus).to.equal(201)


### PR DESCRIPTION
a stakeholder is reporting a crash caused by the result of `trace.getActiveSpan()` being truthy but not having a property `attributes`. it occurs when reading from the db in a custom express middleware. however, i'm not yet able to reproduce. → quick fix and follow-up