### PR TITLE
refactor: Use node:timers/promises/setTimeout

### DIFF
--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -6,7 +6,7 @@ const cds = require('@sap/cds')
 const { expect, GET } = cds.test().in(__dirname + '/bookshop')
 const log = cds.test.log()
 
-const wait = require('util').promisify(setTimeout)
+const wait = require('node:timers/promises').setTimeout
 
 describe('metrics', () => {
   const admin = { auth: { username: 'alice' } }

--- a/test/tracing-messaging.js
+++ b/test/tracing-messaging.js
@@ -3,7 +3,7 @@ module.exports = (CASE, CHECK) => {
   const { expect, POST } = cds.test().in(__dirname + '/bookshop')
   const log = cds.test.log()
 
-  const sleep = require('util').promisify(setTimeout)
+  const sleep = require('node:timers/promises').setTimeout
 
   const admin = { auth: { username: 'alice' } }
 

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -7,7 +7,7 @@ const cds = require('@sap/cds')
 const { expect, GET, POST } = cds.test().in(__dirname + '/bookshop')
 const log = cds.test.log()
 
-const sleep = require('util').promisify(setTimeout)
+const sleep = require('node:timers/promises').setTimeout
 
 describe('tracing', () => {
   const admin = { auth: { username: 'alice' } }


### PR DESCRIPTION
Refactoring to use `require('node:timers/promises').setTimeout` rather than `require('util').promisify(setTimeout)`.

No need to promisify a function as there's a native promise version of that: [Timers Promises API](https://nodejs.org/api/timers.html#timerspromisessettimeoutdelay-value-options)