### PR TITLE
add tracing with sql with out parameters for cap-js/hana

### DIFF
--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -217,7 +217,7 @@ function _addAttributes(span, fn, that, options, args, parent) {
 
 const _addDbRowCount = (span, res) => {
   if (!span.attributes['db.statement']) return
-  if (!['all', 'run'].includes(span.attributes['code.function'])) return
+  if (!['all', 'run', 'exec'].includes(span.attributes['code.function'])) return
 
   let rowCount
   const operation = span.attributes['db.operation']


### PR DESCRIPTION
Trace hana no params:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/aef55a4a-368f-4f56-b02d-4b7d41db621c" />


Trace hana with params:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/6e6ed91e-bb7b-4d4d-85e0-499be7dac240" />
