### PR TITLE
use correct service config in telemetry for messaging services

### DIFF
--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -251,7 +251,7 @@ function trace(req, fn, that, args, opts = {}) {
 
     if (that instanceof cds.RemoteService) kind = SpanKind.CLIENT
     else if (that instanceof cds.MessagingService) {
-      const msg = cds.env.requires.messaging
+      const msg = cds.env.requires[that.name]
       // prettier-ignore
       const xd = (msg.queued || msg.outboxed || msg.outbox) && msg.queued !== false && msg.outboxed !== false && msg.outbox !== false
       if (msg.kind !== 'local-messaging') {


### PR DESCRIPTION
Putting a messaging service at a different name then messaging currently leads to:

TypeError: Cannot read properties of undefined (reading 'queued')
    at trace (/Users/soeren.leibach/Projects/clouddatatransport/node_modules/@cap-js/telemetry/lib/tracing/trace.js:257:23)
    at FileBasedMessaging.emit (/Users/soeren.leibach/Projects/clouddatatransport/node_modules/@cap-js/telemetry/lib/tracing/cds.js:39:14)
    at module.exports (/Users/soeren.leibach/Projects/clouddatatransport/srv/code/transports-on-emitusage-logic.js:38:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async next (/Users/soeren.leibach/Projects/clouddatatransport/node_modules/@sap/cds/lib/srv/srv-dispatch.js:61:17)
    at async TransportService.handle (/Users/soeren.leibach/Projects/clouddatatransport/node_modules/@sap/cds/lib/srv/srv-dispatch.js:59:10)
    at async exportData (/Users/soeren.leibach/Projects/clouddatatransport/srv/code/transport/exportData.js:74:3)
    at async /Users/soeren.leibach/Projects/clouddatatransport/srv/code/transports-on-run-logic.js:34:7 {stack: 'TypeError: Cannot read properties of undefine…port/srv/code/transports-on-run-logic.js:34:7', message: "Cannot read properties of undefined (reading 'queued')"}