### PR TITLE
fix: skip queue metrics setup if no database is connected

### DIFF
--- a/lib/metrics/queue.js
+++ b/lib/metrics/queue.js
@@ -161,6 +161,12 @@ module.exports = () => {
   const registeredServics = new Set()
 
   cds.on('listening', () => {
+    
+    if (!cds.db) {
+       cds.log('telemetry').info('Skipping queue metrics setup as no database is connected')
+       return
+    }
+
     const queueEntity = cds.model.definitions[PERSISTENT_QUEUE_DB_NAME]
     if (!queueEntity) return
 


### PR DESCRIPTION
Currently, queue.js will try to register the `.after` handler for collecting queue metrics even if the CAP app does not have a database, resulting in a crash on startup. 