### PR TITLE
chore: adopt tests to unhandled action throws

### DIFF
--- a/lib/exporter/ConsoleMetricExporter.js
+++ b/lib/exporter/ConsoleMetricExporter.js
@@ -56,8 +56,10 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
         }
         LOG.info(toLog)
       } else {
-        const pool = {}, queue = {}, other = {}
-        const identify = (name) => {
+        const pool = {},
+          queue = {},
+          other = {}
+        const identify = name => {
           let match = name.match(/^db\.pool\.(\w+)$/)
           if (match) return { collector: pool, name: match[1] }
           match = name.match(/^queue\.(\w+)$/)
@@ -93,13 +95,19 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
         for (const tenant of Object.keys(queue)) {
           let toLog = `queue${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}:`
           toLog += `\n     cold | remaining | min storage time | med storage time | max storage time | incoming | outgoing`
-          toLog += `\n  ${`${queue[tenant].cold_entries}`.padStart(7)
-            } | ${`${queue[tenant].remaining_entries}`.padStart(9)
-            } | ${`${queue[tenant].min_storage_time_in_seconds}`.padStart(16)
-            } | ${`${queue[tenant].med_storage_time_in_seconds}`.padStart(16)
-            } | ${`${queue[tenant].max_storage_time_in_seconds}`.padStart(16)
-            } | ${`${queue[tenant].incoming_messages}`.padStart(8)
-            } | ${`${queue[tenant].outgoing_messages}`.padStart(8)}`
+          toLog += `\n  ${`${queue[tenant].cold_entries}`.padStart(
+            7
+          )} | ${`${queue[tenant].remaining_entries}`.padStart(
+            9
+          )} | ${`${queue[tenant].min_storage_time_in_seconds}`.padStart(
+            16
+          )} | ${`${queue[tenant].med_storage_time_in_seconds}`.padStart(
+            16
+          )} | ${`${queue[tenant].max_storage_time_in_seconds}`.padStart(
+            16
+          )} | ${`${queue[tenant].incoming_messages}`.padStart(8)} | ${`${queue[tenant].outgoing_messages}`.padStart(
+            8
+          )}`
           LOG.info(toLog)
         }
 

--- a/lib/tracing/trace.js
+++ b/lib/tracing/trace.js
@@ -322,7 +322,7 @@ function trace(req, fn, that, args, opts = {}) {
 
     // SAP Passport
     // REVISIT: fallback for _hana_prom = false
-    const dbc = opts.dbc || name.startsWith('@cap-js/hana') && that.dbc
+    const dbc = opts.dbc || (name.startsWith('@cap-js/hana') && that.dbc)
     if (process.env.SAP_PASSPORT && dbc?.set) {
       const { spanId, traceId } = span.spanContext()
       // REVISIT: @sap/dsrpassport uses '0226' for VARPARTOFFSET

--- a/test/metrics-outbox-disabled.test.js
+++ b/test/metrics-outbox-disabled.test.js
@@ -1,65 +1,65 @@
-process.env.cds_requires_outbox = true;
+process.env.cds_requires_outbox = true
 process.env.cds_requires_telemetry_metrics = JSON.stringify({
   config: { exportIntervalMillis: 100 },
   _db_pool: false,
   _queue: false,
   exporter: {
-    module: "@opentelemetry/sdk-metrics",
-    class: "ConsoleMetricExporter",
-  },
-});
+    module: '@opentelemetry/sdk-metrics',
+    class: 'ConsoleMetricExporter'
+  }
+})
 
 // Mock console.dir to capture logs ConsoleMetricExporter writes
-const consoleDirLogs = [];
-jest.spyOn(console, "dir").mockImplementation((...args) => {
-  consoleDirLogs.push(args);
-});
+const consoleDirLogs = []
+jest.spyOn(console, 'dir').mockImplementation((...args) => {
+  consoleDirLogs.push(args)
+})
 
-const cds = require("@sap/cds");
-const { setTimeout: wait } = require("node:timers/promises");
+const cds = require('@sap/cds')
+const { setTimeout: wait } = require('node:timers/promises')
 
-const { expect, GET } = cds.test(__dirname + "/bookshop", "--with-mocks");
+const { expect, GET } = cds.test(__dirname + '/bookshop', '--with-mocks')
 
 function metricValue(metric) {
   const mostRecentMetricLog = consoleDirLogs.findLast(
-    (metricLog) => metricLog[0].descriptor.name === `queue.${metric}`
-  )?.[0];
+    metricLog => metricLog[0].descriptor.name === `queue.${metric}`
+  )?.[0]
 
-  if (!mostRecentMetricLog) return null;
+  if (!mostRecentMetricLog) return null
 
-  return mostRecentMetricLog.dataPoints[0].value;
+  return mostRecentMetricLog.dataPoints[0].value
 }
 
-describe("queue metrics is disabled", () => {
-  const admin = { auth: { username: "alice" } };
+describe('queue metrics is disabled', () => {
+  const admin = { auth: { username: 'alice' } }
   beforeAll(async () => {
-    const proxyService = await cds.connect.to("ProxyService");
-    const externalService = await cds.connect.to("ExternalService");
-    const queuedService = cds.outboxed(externalService);
+    const proxyService = await cds.connect.to('ProxyService')
+    const externalService = await cds.connect.to('ExternalService')
+    const queuedService = cds.outboxed(externalService)
 
-    proxyService.on("proxyCallToExternalService", async (req) => {
-      await queuedService.send("call", {});
-      return req.reply("OK");
-    });
+    proxyService.on('proxyCallToExternalService', async req => {
+      await queuedService.send('call', {})
+      return req.reply('OK')
+    })
 
-    externalService.before("*", () => {});
-  });
+    externalService.before('*', () => {})
+  })
 
-  beforeEach(() => (consoleDirLogs.length = 0));
+  beforeEach(() => (consoleDirLogs.length = 0))
 
-  test("metrics are not collected", async () => {
-    if (cds.version.split(".")[0] < 9) return;
+  test('metrics are not collected', async () => {
+    if (cds.version.split('.')[0] < 9) return
 
-    await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
+    await GET('/odata/v4/proxy/proxyCallToExternalService', admin)
 
-    await wait(150); // Wait for metrics to be collected
+    await wait(150) // Wait for metrics to be collected
 
-    expect(metricValue('cold_entries')).to.eq(null);
-    expect(metricValue('remaining_entries')).to.eq(null);
-    expect(metricValue('incoming_messages')).to.eq(null);
-    expect(metricValue('outgoing_messages')).to.eq(null);
-    expect(metricValue('min_storage_time_in_seconds')).to.eq(null);
-    expect(metricValue('med_storage_time_in_seconds')).to.eq(null);
-    expect(metricValue('max_storage_time_in_seconds')).to.eq(null);
-  });
-});
+    expect(metricValue('cold_entries')).to.eq(null)
+    expect(metricValue('remaining_entries')).to.eq(null)
+    expect(metricValue('incoming_messages')).to.eq(null)
+    expect(metricValue('outgoing_messages')).to.eq(null)
+    expect(metricValue('min_storage_time_in_seconds')).to.eq(null)
+    expect(metricValue('med_storage_time_in_seconds')).to.eq(null)
+    expect(metricValue('max_storage_time_in_seconds')).to.eq(null)
+  })
+})

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -55,7 +55,7 @@ describe("queue metrics for multi tenant service", () => {
   beforeAll(async () => {
     const proxyService = await cds.connect.to("ProxyService");
     const unboxedService = await cds.connect.to("ExternalService");
-    const queuedService = cds.queued(unboxedService);
+    const queuedService = cds.outboxed(unboxedService);
 
     proxyService.on("proxyCallToExternalService", async (req) => {
       totalInc[cds.context.tenant] += 1;

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -55,7 +55,7 @@ describe("queue metrics for multi tenant service", () => {
   beforeAll(async () => {
     const proxyService = await cds.connect.to("ProxyService");
     const unboxedService = await cds.connect.to("ExternalService");
-    const queuedService = cds.outboxed(unboxedService);
+    const queuedService = cds.queued(unboxedService);
 
     proxyService.on("proxyCallToExternalService", async (req) => {
       totalInc[cds.context.tenant] += 1;

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -1,272 +1,260 @@
-process.env.cds_requires_outbox = true;
+process.env.cds_requires_outbox = true
 process.env.cds_requires_telemetry_metrics = JSON.stringify({
   config: { exportIntervalMillis: 100 },
   _db_pool: false,
   _queue: true,
   exporter: {
-    module: "@opentelemetry/sdk-metrics",
-    class: "ConsoleMetricExporter",
-  },
-});
+    module: '@opentelemetry/sdk-metrics',
+    class: 'ConsoleMetricExporter'
+  }
+})
 
 // Mock console.dir to capture logs ConsoleMetricExporter writes
-const consoleDirLogs = [];
-jest.spyOn(console, "dir").mockImplementation((...args) => {
-  consoleDirLogs.push(args);
-});
+const consoleDirLogs = []
+jest.spyOn(console, 'dir').mockImplementation((...args) => {
+  consoleDirLogs.push(args)
+})
 
-const cds = require("@sap/cds");
-const { setTimeout: wait } = require("node:timers/promises");
+const cds = require('@sap/cds')
+const { setTimeout: wait } = require('node:timers/promises')
 
-const { expect, GET, axios } = cds.test(
-  __dirname + "/bookshop",
-  "--profile",
-  "multitenancy",
-  "--with-mocks"
-);
-axios.defaults.validateStatus = () => true;
+const { expect, GET, axios } = cds.test(__dirname + '/bookshop', '--profile', 'multitenancy', '--with-mocks')
+axios.defaults.validateStatus = () => true
 
 function metricValue(tenant, metric) {
   const mostRecentMetricLog = consoleDirLogs.findLast(
-    (metricLog) => metricLog[0].descriptor.name === `queue.${metric}`
-  )?.[0];
+    metricLog => metricLog[0].descriptor.name === `queue.${metric}`
+  )?.[0]
 
-  if (!mostRecentMetricLog) return null;
+  if (!mostRecentMetricLog) return null
 
   const mostRecentTenantDataPoint = mostRecentMetricLog.dataPoints.find(
-    (dp) => dp.attributes["sap.tenancy.tenant_id"] === tenant
-  );
-  return mostRecentTenantDataPoint ? mostRecentTenantDataPoint.value : null;
+    dp => dp.attributes['sap.tenancy.tenant_id'] === tenant
+  )
+  return mostRecentTenantDataPoint ? mostRecentTenantDataPoint.value : null
 }
 
-describe("queue metrics for multi tenant service", () => {
-  const T1 = "tenant_1";
-  const T2 = "tenant_2";
+describe('queue metrics for multi tenant service', () => {
+  const T1 = 'tenant_1'
+  const T2 = 'tenant_2'
 
   const user = {
     [T1]: { auth: { username: `user_${T1}` } },
-    [T2]: { auth: { username: `user_${T2}` } },
-  };
+    [T2]: { auth: { username: `user_${T2}` } }
+  }
 
-  let totalCold = { [T1]: 0, [T2]: 0 };
-  let totalInc = { [T1]: 0, [T2]: 0 };
-  let totalOut = { [T1]: 0, [T2]: 0 };
+  let totalCold = { [T1]: 0, [T2]: 0 }
+  let totalInc = { [T1]: 0, [T2]: 0 }
+  let totalOut = { [T1]: 0, [T2]: 0 }
 
   beforeAll(async () => {
-    const proxyService = await cds.connect.to("ProxyService");
-    const unboxedService = await cds.connect.to("ExternalService");
-    const queuedService = cds.outboxed(unboxedService);
+    const proxyService = await cds.connect.to('ProxyService')
+    const unboxedService = await cds.connect.to('ExternalService')
+    const queuedService = cds.outboxed(unboxedService)
 
-    proxyService.on("proxyCallToExternalService", async (req) => {
-      totalInc[cds.context.tenant] += 1;
-      await queuedService.send("call", {});
-      return req.reply("OK");
-    });
+    proxyService.on('proxyCallToExternalService', async req => {
+      totalInc[cds.context.tenant] += 1
+      await queuedService.send('call', {})
+      return req.reply('OK')
+    })
 
-    unboxedService.before("*", () => {
-      totalOut[cds.context.tenant] += 1;
-    });
+    unboxedService.before('*', () => {
+      totalOut[cds.context.tenant] += 1
+    })
 
-    const mts = await cds.connect.to("cds.xt.DeploymentService");
-    await mts.subscribe(T1);
-    await mts.subscribe(T2);
-  });
+    const mts = await cds.connect.to('cds.xt.DeploymentService')
+    await mts.subscribe(T1)
+    await mts.subscribe(T2)
+  })
 
-  beforeEach(() => (consoleDirLogs.length = 0));
+  beforeEach(() => (consoleDirLogs.length = 0))
 
-  describe("given the target service succeeds immediately", () => {
-    let unboxedService;
+  describe('given the target service succeeds immediately', () => {
+    let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.on("call", (req) => {
-        return req.reply("OK");
-      });
-    });
+      unboxedService.on('call', req => {
+        return req.reply('OK')
+      })
+    })
 
     afterAll(async () => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.on !== "call"
-      );
-    });
-    test("metrics are collected per tenant", async () => {
-      if (cds.version.split(".")[0] < 9) return;
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.on !== 'call')
+    })
+    test('metrics are collected per tenant', async () => {
+      if (cds.version.split('.')[0] < 9) return
 
       await Promise.all([
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T1]),
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T2]),
-      ]);
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T1]),
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T2])
+      ])
 
-      await wait(150); // Wait for metrics to be collected
+      await wait(150) // Wait for metrics to be collected
 
-      expect(metricValue(T1, "cold_entries")).to.eq(totalCold[T1]);
-      expect(metricValue(T1, "incoming_messages")).to.eq(totalInc[T1]);
-      expect(metricValue(T1, "outgoing_messages")).to.eq(totalOut[T1]);
-      expect(metricValue(T1, "remaining_entries")).to.eq(0);
-      expect(metricValue(T1, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue(T1, 'cold_entries')).to.eq(totalCold[T1])
+      expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
+      expect(metricValue(T1, 'outgoing_messages')).to.eq(totalOut[T1])
+      expect(metricValue(T1, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T1, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'max_storage_time_in_seconds')).to.eq(0)
 
-      expect(metricValue(T2, "cold_entries")).to.eq(totalCold[T2]);
-      expect(metricValue(T2, "incoming_messages")).to.eq(totalInc[T2]);
-      expect(metricValue(T2, "outgoing_messages")).to.eq(totalOut[T2]);
-      expect(metricValue(T2, "remaining_entries")).to.eq(0);
-      expect(metricValue(T2, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "max_storage_time_in_seconds")).to.eq(0);
-    });
-  });
+      expect(metricValue(T2, 'cold_entries')).to.eq(totalCold[T2])
+      expect(metricValue(T2, 'incoming_messages')).to.eq(totalInc[T2])
+      expect(metricValue(T2, 'outgoing_messages')).to.eq(totalOut[T2])
+      expect(metricValue(T2, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T2, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'max_storage_time_in_seconds')).to.eq(0)
+    })
+  })
 
-  describe("given a target service that requires retries", () => {
-    if (cds.version.split(".")[0] < 9) return;
+  describe('given a target service that requires retries', () => {
+    if (cds.version.split('.')[0] < 9) return
 
-    let currentRetryCount = { [T1]: 0, [T2]: 0 };
-    let unboxedService;
+    let currentRetryCount = { [T1]: 0, [T2]: 0 }
+    let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.before("call", (req) => {
-        if ((currentRetryCount[cds.context.tenant] += 1) <= 2)
-          return req.reject({ status: 503 });
-      });
-    });
+      unboxedService.before('call', req => {
+        if ((currentRetryCount[cds.context.tenant] += 1) <= 2) return req.reject({ status: 503 })
+      })
+    })
 
     afterAll(() => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.before !== "call"
-      );
-    });
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.before !== 'call')
+    })
 
-    test("storage time increases before message can be delivered", async () => {
-      if (cds.version.split(".")[0] < 9) return;
+    test('storage time increases before message can be delivered', async () => {
+      if (cds.version.split('.')[0] < 9) return
 
-      const timeOfInitialCall = Date.now();
+      const timeOfInitialCall = Date.now()
       await Promise.all([
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T1]),
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T2]),
-      ]);
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T1]),
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T2])
+      ])
 
-      await wait(150); // ... for metrics to be collected
-      expect(currentRetryCount[T1]).to.eq(1);
-      expect(currentRetryCount[T2]).to.eq(1);
+      await wait(150) // ... for metrics to be collected
+      expect(currentRetryCount[T1]).to.eq(1)
+      expect(currentRetryCount[T2]).to.eq(1)
 
-      expect(metricValue(T1, "cold_entries")).to.eq(totalCold[T1]);
-      expect(metricValue(T1, "incoming_messages")).to.eq(totalInc[T1]);
-      expect(metricValue(T1, "outgoing_messages")).to.eq(totalOut[T1]);
-      expect(metricValue(T1, "remaining_entries")).to.eq(1);
-      expect(metricValue(T1, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue(T1, 'cold_entries')).to.eq(totalCold[T1])
+      expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
+      expect(metricValue(T1, 'outgoing_messages')).to.eq(totalOut[T1])
+      expect(metricValue(T1, 'remaining_entries')).to.eq(1)
+      expect(metricValue(T1, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'max_storage_time_in_seconds')).to.eq(0)
 
-      expect(metricValue(T2, "cold_entries")).to.eq(totalCold[T2]);
-      expect(metricValue(T2, "incoming_messages")).to.eq(totalInc[T2]);
-      expect(metricValue(T2, "outgoing_messages")).to.eq(totalOut[T2]);
-      expect(metricValue(T2, "remaining_entries")).to.eq(1);
-      expect(metricValue(T2, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue(T2, 'cold_entries')).to.eq(totalCold[T2])
+      expect(metricValue(T2, 'incoming_messages')).to.eq(totalInc[T2])
+      expect(metricValue(T2, 'outgoing_messages')).to.eq(totalOut[T2])
+      expect(metricValue(T2, 'remaining_entries')).to.eq(1)
+      expect(metricValue(T2, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'max_storage_time_in_seconds')).to.eq(0)
 
       // Wait for the first retry to be initiated
-      while (currentRetryCount[T1] < 2) await wait(100);
-      while (currentRetryCount[T2] < 2) await wait(100);
-      await wait(150); // ... for the retry to be processed and metrics to be collected
-      expect(currentRetryCount[T1]).to.eq(2);
-      expect(currentRetryCount[T2]).to.eq(2);
+      while (currentRetryCount[T1] < 2) await wait(100)
+      while (currentRetryCount[T2] < 2) await wait(100)
+      await wait(150) // ... for the retry to be processed and metrics to be collected
+      expect(currentRetryCount[T1]).to.eq(2)
+      expect(currentRetryCount[T2]).to.eq(2)
 
       // Wait until at least 1 second has passed since the initial call
-      const timeAfterFirstRetry = Date.now();
+      const timeAfterFirstRetry = Date.now()
       if (timeAfterFirstRetry - timeOfInitialCall < 1000) {
-        await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall));
+        await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall))
       }
 
-      await wait(200); // ... for metrics to be collected again
+      await wait(200) // ... for metrics to be collected again
 
-      expect(metricValue(T1, "cold_entries")).to.eq(totalCold[T1]);
-      expect(metricValue(T1, "incoming_messages")).to.eq(totalInc[T1]);
-      expect(metricValue(T1, "outgoing_messages")).to.eq(totalOut[T1]);
-      expect(metricValue(T1, "remaining_entries")).to.eq(1);
-      expect(metricValue(T1, "min_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue(T1, "med_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue(T1, "max_storage_time_in_seconds")).to.be.gte(1);
+      expect(metricValue(T1, 'cold_entries')).to.eq(totalCold[T1])
+      expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
+      expect(metricValue(T1, 'outgoing_messages')).to.eq(totalOut[T1])
+      expect(metricValue(T1, 'remaining_entries')).to.eq(1)
+      expect(metricValue(T1, 'min_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue(T1, 'med_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue(T1, 'max_storage_time_in_seconds')).to.be.gte(1)
 
-      expect(metricValue(T2, "cold_entries")).to.eq(totalCold[T2]);
-      expect(metricValue(T2, "incoming_messages")).to.eq(totalInc[T2]);
-      expect(metricValue(T2, "outgoing_messages")).to.eq(totalOut[T2]);
-      expect(metricValue(T2, "remaining_entries")).to.eq(1);
-      expect(metricValue(T2, "min_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue(T2, "med_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue(T2, "max_storage_time_in_seconds")).to.be.gte(1);
+      expect(metricValue(T2, 'cold_entries')).to.eq(totalCold[T2])
+      expect(metricValue(T2, 'incoming_messages')).to.eq(totalInc[T2])
+      expect(metricValue(T2, 'outgoing_messages')).to.eq(totalOut[T2])
+      expect(metricValue(T2, 'remaining_entries')).to.eq(1)
+      expect(metricValue(T2, 'min_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue(T2, 'med_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue(T2, 'max_storage_time_in_seconds')).to.be.gte(1)
 
       // Wait for the second retry to be initiated
-      while (currentRetryCount[T1] < 3) await wait(100);
-      while (currentRetryCount[T2] < 3) await wait(100);
-      await wait(150); // ... for the retry to be processed and metrics to be collected
-      expect(currentRetryCount[T1]).to.eq(3);
-      expect(currentRetryCount[T2]).to.eq(3);
+      while (currentRetryCount[T1] < 3) await wait(100)
+      while (currentRetryCount[T2] < 3) await wait(100)
+      await wait(150) // ... for the retry to be processed and metrics to be collected
+      expect(currentRetryCount[T1]).to.eq(3)
+      expect(currentRetryCount[T2]).to.eq(3)
 
-      expect(metricValue(T1, "cold_entries")).to.eq(totalCold[T1]);
-      expect(metricValue(T1, "incoming_messages")).to.eq(totalInc[T1]);
-      expect(metricValue(T1, "outgoing_messages")).to.eq(totalOut[T1]);
-      expect(metricValue(T1, "remaining_entries")).to.eq(0);
-      expect(metricValue(T1, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue(T1, 'cold_entries')).to.eq(totalCold[T1])
+      expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
+      expect(metricValue(T1, 'outgoing_messages')).to.eq(totalOut[T1])
+      expect(metricValue(T1, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T1, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'max_storage_time_in_seconds')).to.eq(0)
 
-      expect(metricValue(T2, "cold_entries")).to.eq(totalCold[T2]);
-      expect(metricValue(T2, "incoming_messages")).to.eq(totalInc[T2]);
-      expect(metricValue(T2, "outgoing_messages")).to.eq(totalOut[T2]);
-      expect(metricValue(T2, "remaining_entries")).to.eq(0);
-      expect(metricValue(T2, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "max_storage_time_in_seconds")).to.eq(0);
-    });
-  });
+      expect(metricValue(T2, 'cold_entries')).to.eq(totalCold[T2])
+      expect(metricValue(T2, 'incoming_messages')).to.eq(totalInc[T2])
+      expect(metricValue(T2, 'outgoing_messages')).to.eq(totalOut[T2])
+      expect(metricValue(T2, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T2, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'max_storage_time_in_seconds')).to.eq(0)
+    })
+  })
 
-  describe("given a taget service that fails unrecoverably", () => {
-    let unboxedService;
+  describe('given a taget service that fails unrecoverably', () => {
+    let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.before("call", (req) => {
-        totalCold[cds.context.tenant] += 1;
-        return req.reject({ status: 418, unrecoverable: true });
-      });
-    });
+      unboxedService.before('call', req => {
+        totalCold[cds.context.tenant] += 1
+        return req.reject({ status: 418, unrecoverable: true })
+      })
+    })
 
     afterAll(async () => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.before !== "call"
-      );
-    });
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.before !== 'call')
+    })
 
-    test("cold entry is observed", async () => {
-      if (cds.version.split(".")[0] < 9) return;
+    test('cold entry is observed', async () => {
+      if (cds.version.split('.')[0] < 9) return
 
       await Promise.all([
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T1]),
-        GET("/odata/v4/proxy/proxyCallToExternalService", user[T2]),
-      ]);
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T1]),
+        GET('/odata/v4/proxy/proxyCallToExternalService', user[T2])
+      ])
 
-      await wait(150); // ... for metrics to be collected
+      await wait(150) // ... for metrics to be collected
 
-      expect(metricValue(T1, "cold_entries")).to.eq(totalCold[T1]);
-      expect(metricValue(T1, "incoming_messages")).to.eq(totalInc[T1]);
-      expect(metricValue(T1, "outgoing_messages")).to.eq(totalOut[T1]);
-      expect(metricValue(T1, "remaining_entries")).to.eq(0);
-      expect(metricValue(T1, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T1, "max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue(T1, 'cold_entries')).to.eq(totalCold[T1])
+      expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
+      expect(metricValue(T1, 'outgoing_messages')).to.eq(totalOut[T1])
+      expect(metricValue(T1, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T1, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T1, 'max_storage_time_in_seconds')).to.eq(0)
 
-      expect(metricValue(T2, "cold_entries")).to.eq(totalCold[T2]);
-      expect(metricValue(T2, "incoming_messages")).to.eq(totalInc[T2]);
-      expect(metricValue(T2, "outgoing_messages")).to.eq(totalOut[T2]);
-      expect(metricValue(T2, "remaining_entries")).to.eq(0);
-      expect(metricValue(T2, "min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue(T2, "max_storage_time_in_seconds")).to.eq(0);
-    });
-  });
-});
+      expect(metricValue(T2, 'cold_entries')).to.eq(totalCold[T2])
+      expect(metricValue(T2, 'incoming_messages')).to.eq(totalInc[T2])
+      expect(metricValue(T2, 'outgoing_messages')).to.eq(totalOut[T2])
+      expect(metricValue(T2, 'remaining_entries')).to.eq(0)
+      expect(metricValue(T2, 'min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue(T2, 'max_storage_time_in_seconds')).to.eq(0)
+    })
+  })
+})

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -40,7 +40,7 @@ describe("queue metrics for single tenant service", () => {
   beforeAll(async () => {
     const proxyService = await cds.connect.to("ProxyService");
     const externalService = await cds.connect.to("ExternalService");
-    const queuedService = cds.outboxed(externalService);
+    const queuedService = cds.queued(externalService);
 
     proxyService.on("proxyCallToExternalService", async (req) => {
       await queuedService.send("call", {});

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -55,21 +55,39 @@ describe("queue metrics for single tenant service", () => {
 
   beforeEach(() => (consoleDirLogs.length = 0));
 
-  test("metrics are collected", async () => {
-    if (cds.version.split(".")[0] < 9) return;
+  describe("given the target service succeeds immediately", () => {
+    let unboxedService
 
-    await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
+    beforeAll(async () => {
+      unboxedService = await cds.connect.to("ExternalService");
 
-    await wait(150); // Wait for metrics to be collected
+      unboxedService.on("call", (req) => {
+        return req.reply("OK");
+      })
+    })
 
-    expect(metricValue("cold_entries")).to.eq(totalCold);
-    expect(metricValue("remaining_entries")).to.eq(0);
-    expect(metricValue("incoming_messages")).to.eq(totalInc);
-    expect(metricValue("outgoing_messages")).to.eq(totalOut);
-    expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
-    expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
-    expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
-  });
+    afterAll(async () => {
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(
+        (handler) => handler.on !== "call"
+      );
+    });
+
+    test("metrics are collected", async () => {
+      if (cds.version.split(".")[0] < 9) return;
+      
+      await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
+      
+      await wait(150); // Wait for metrics to be collected
+      
+      expect(metricValue("cold_entries")).to.eq(totalCold);
+      expect(metricValue("remaining_entries")).to.eq(0);
+      expect(metricValue("incoming_messages")).to.eq(totalInc);
+      expect(metricValue("outgoing_messages")).to.eq(totalOut);
+      expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
+    });
+  })
 
   describe("given a target service that requires retries", () => {
     let currentRetryCount = 0;

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -40,7 +40,7 @@ describe("queue metrics for single tenant service", () => {
   beforeAll(async () => {
     const proxyService = await cds.connect.to("ProxyService");
     const externalService = await cds.connect.to("ExternalService");
-    const queuedService = cds.queued(externalService);
+    const queuedService = cds.outboxed(externalService);
 
     proxyService.on("proxyCallToExternalService", async (req) => {
       await queuedService.send("call", {});

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -1,201 +1,195 @@
-process.env.cds_requires_outbox = true;
+process.env.cds_requires_outbox = true
 process.env.cds_requires_telemetry_metrics = JSON.stringify({
   config: { exportIntervalMillis: 100 },
   _db_pool: false,
   _queue: true,
   exporter: {
-    module: "@opentelemetry/sdk-metrics",
-    class: "ConsoleMetricExporter",
-  },
-});
+    module: '@opentelemetry/sdk-metrics',
+    class: 'ConsoleMetricExporter'
+  }
+})
 
 // Mock console.dir to capture logs ConsoleMetricExporter writes
-const consoleDirLogs = [];
-jest.spyOn(console, "dir").mockImplementation((...args) => {
-  consoleDirLogs.push(args);
-});
+const consoleDirLogs = []
+jest.spyOn(console, 'dir').mockImplementation((...args) => {
+  consoleDirLogs.push(args)
+})
 
-const cds = require("@sap/cds");
-const { setTimeout: wait } = require("node:timers/promises");
+const cds = require('@sap/cds')
+const { setTimeout: wait } = require('node:timers/promises')
 
-const { expect, GET } = cds.test(__dirname + "/bookshop", "--with-mocks");
+const { expect, GET } = cds.test(__dirname + '/bookshop', '--with-mocks')
 
 function metricValue(metric) {
   const mostRecentMetricLog = consoleDirLogs.findLast(
-    (metricLog) => metricLog[0].descriptor.name === `queue.${metric}`
-  )?.[0];
+    metricLog => metricLog[0].descriptor.name === `queue.${metric}`
+  )?.[0]
 
-  if (!mostRecentMetricLog) return null;
+  if (!mostRecentMetricLog) return null
 
-  return mostRecentMetricLog.dataPoints[0].value;
+  return mostRecentMetricLog.dataPoints[0].value
 }
 
-describe("queue metrics for single tenant service", () => {
-  let totalCold = 0;
-  let totalInc = 0;
-  let totalOut = 0;
+describe('queue metrics for single tenant service', () => {
+  let totalCold = 0
+  let totalInc = 0
+  let totalOut = 0
 
-  const admin = { auth: { username: "alice" } };
+  const admin = { auth: { username: 'alice' } }
 
   beforeAll(async () => {
-    const proxyService = await cds.connect.to("ProxyService");
-    const externalService = await cds.connect.to("ExternalService");
-    const queuedService = cds.outboxed(externalService);
+    const proxyService = await cds.connect.to('ProxyService')
+    const externalService = await cds.connect.to('ExternalService')
+    const queuedService = cds.outboxed(externalService)
 
-    proxyService.on("proxyCallToExternalService", async (req) => {
-      await queuedService.send("call", {});
-      totalInc += 1;
-      return req.reply("OK");
-    });
+    proxyService.on('proxyCallToExternalService', async req => {
+      await queuedService.send('call', {})
+      totalInc += 1
+      return req.reply('OK')
+    })
 
-    externalService.before("*", () => {
-      totalOut += 1;
-    });
-  });
+    externalService.before('*', () => {
+      totalOut += 1
+    })
+  })
 
-  beforeEach(() => (consoleDirLogs.length = 0));
+  beforeEach(() => (consoleDirLogs.length = 0))
 
-  describe("given the target service succeeds immediately", () => {
+  describe('given the target service succeeds immediately', () => {
     let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.on("call", (req) => {
-        return req.reply("OK");
+      unboxedService.on('call', req => {
+        return req.reply('OK')
       })
     })
 
     afterAll(async () => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.on !== "call"
-      );
-    });
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.on !== 'call')
+    })
 
-    test("metrics are collected", async () => {
-      if (cds.version.split(".")[0] < 9) return;
-      
-      await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
-      
-      await wait(150); // Wait for metrics to be collected
-      
-      expect(metricValue("cold_entries")).to.eq(totalCold);
-      expect(metricValue("remaining_entries")).to.eq(0);
-      expect(metricValue("incoming_messages")).to.eq(totalInc);
-      expect(metricValue("outgoing_messages")).to.eq(totalOut);
-      expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
-    });
+    test('metrics are collected', async () => {
+      if (cds.version.split('.')[0] < 9) return
+
+      await GET('/odata/v4/proxy/proxyCallToExternalService', admin)
+
+      await wait(150) // Wait for metrics to be collected
+
+      expect(metricValue('cold_entries')).to.eq(totalCold)
+      expect(metricValue('remaining_entries')).to.eq(0)
+      expect(metricValue('incoming_messages')).to.eq(totalInc)
+      expect(metricValue('outgoing_messages')).to.eq(totalOut)
+      expect(metricValue('min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('max_storage_time_in_seconds')).to.eq(0)
+    })
   })
 
-  describe("given a target service that requires retries", () => {
-    let currentRetryCount = 0;
-    let unboxedService;
+  describe('given a target service that requires retries', () => {
+    let currentRetryCount = 0
+    let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.before("call", (req) => {
-        if ((currentRetryCount += 1) <= 2) return req.reject({ status: 503 });
-      });
-    });
+      unboxedService.before('call', req => {
+        if ((currentRetryCount += 1) <= 2) return req.reject({ status: 503 })
+      })
+    })
 
     afterAll(async () => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.before !== "call"
-      );
-    });
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.before !== 'call')
+    })
 
     beforeEach(() => {
-      currentRetryCount = 0;
-    });
+      currentRetryCount = 0
+    })
 
-    test("storage time increases before message can be delivered", async () => {
-      if (cds.version.split(".")[0] < 9) return;
+    test('storage time increases before message can be delivered', async () => {
+      if (cds.version.split('.')[0] < 9) return
 
-      const timeOfInitialCall = Date.now();
-      await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
+      const timeOfInitialCall = Date.now()
+      await GET('/odata/v4/proxy/proxyCallToExternalService', admin)
 
-      await wait(150); // ... for metrics to be collected
-      expect(currentRetryCount).to.eq(1);
+      await wait(150) // ... for metrics to be collected
+      expect(currentRetryCount).to.eq(1)
 
-      expect(metricValue("cold_entries")).to.eq(totalCold);
-      expect(metricValue("remaining_entries")).to.eq(1);
-      expect(metricValue("incoming_messages")).to.eq(totalInc);
-      expect(metricValue("outgoing_messages")).to.eq(totalOut);
-      expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
+      expect(metricValue('cold_entries')).to.eq(totalCold)
+      expect(metricValue('remaining_entries')).to.eq(1)
+      expect(metricValue('incoming_messages')).to.eq(totalInc)
+      expect(metricValue('outgoing_messages')).to.eq(totalOut)
+      expect(metricValue('min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('max_storage_time_in_seconds')).to.eq(0)
 
       // Wait for the first retry to be initiated
-      while (currentRetryCount < 2) await wait(100);
-      await wait(150); // ... for the retry to be processed and metrics to be collected
-      expect(currentRetryCount).to.eq(2);
+      while (currentRetryCount < 2) await wait(100)
+      await wait(150) // ... for the retry to be processed and metrics to be collected
+      expect(currentRetryCount).to.eq(2)
 
       // Wait until at least 1 second has passed since the initial call
-      const timeAfterFirstRetry = Date.now();
+      const timeAfterFirstRetry = Date.now()
       if (timeAfterFirstRetry - timeOfInitialCall < 1000) {
-        await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall));
+        await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall))
       }
 
-      await wait(150); // ... for metrics to be collected again
+      await wait(150) // ... for metrics to be collected again
 
-      expect(metricValue("cold_entries")).to.eq(totalCold);
-      expect(metricValue("remaining_entries")).to.eq(1);
-      expect(metricValue("incoming_messages")).to.eq(totalInc);
-      expect(metricValue("outgoing_messages")).to.eq(totalOut);
-      expect(metricValue("min_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue("med_storage_time_in_seconds")).to.be.gte(1);
-      expect(metricValue("max_storage_time_in_seconds")).to.be.gte(1);
+      expect(metricValue('cold_entries')).to.eq(totalCold)
+      expect(metricValue('remaining_entries')).to.eq(1)
+      expect(metricValue('incoming_messages')).to.eq(totalInc)
+      expect(metricValue('outgoing_messages')).to.eq(totalOut)
+      expect(metricValue('min_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue('med_storage_time_in_seconds')).to.be.gte(1)
+      expect(metricValue('max_storage_time_in_seconds')).to.be.gte(1)
 
       // Wait for the second retry to be initiated
-      while (currentRetryCount < 3) await wait(100);
-      await wait(150); // ... for the retry to be processed and metrics to be collected
-      expect(currentRetryCount).to.eq(3);
+      while (currentRetryCount < 3) await wait(100)
+      await wait(150) // ... for the retry to be processed and metrics to be collected
+      expect(currentRetryCount).to.eq(3)
 
-      expect(metricValue("cold_entries")).to.eq(totalCold);
-      expect(metricValue("remaining_entries")).to.eq(0);
-      expect(metricValue("incoming_messages")).to.eq(totalInc);
-      expect(metricValue("outgoing_messages")).to.eq(totalOut);
-      expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
-    });
-  });
+      expect(metricValue('cold_entries')).to.eq(totalCold)
+      expect(metricValue('remaining_entries')).to.eq(0)
+      expect(metricValue('incoming_messages')).to.eq(totalInc)
+      expect(metricValue('outgoing_messages')).to.eq(totalOut)
+      expect(metricValue('min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('max_storage_time_in_seconds')).to.eq(0)
+    })
+  })
 
-  describe("given a target service that fails unrecoverably", () => {
-    let unboxedService;
+  describe('given a target service that fails unrecoverably', () => {
+    let unboxedService
 
     beforeAll(async () => {
-      unboxedService = await cds.connect.to("ExternalService");
+      unboxedService = await cds.connect.to('ExternalService')
 
-      unboxedService.before("call", (req) => {
-        totalCold += 1;
-        return req.reject({ status: 418, unrecoverable: true });
-      });
-    });
+      unboxedService.before('call', req => {
+        totalCold += 1
+        return req.reject({ status: 418, unrecoverable: true })
+      })
+    })
 
     afterAll(async () => {
-      unboxedService.handlers.before = unboxedService.handlers.before.filter(
-        (handler) => handler.before !== "call"
-      );
-    });
+      unboxedService.handlers.before = unboxedService.handlers.before.filter(handler => handler.before !== 'call')
+    })
 
-    test("cold entry is observed", async () => {
-      if (cds.version.split(".")[0] < 9) return;
+    test('cold entry is observed', async () => {
+      if (cds.version.split('.')[0] < 9) return
 
-      await GET("/odata/v4/proxy/proxyCallToExternalService", admin);
+      await GET('/odata/v4/proxy/proxyCallToExternalService', admin)
 
-      await wait(150); // ... for metrics to be collected
+      await wait(150) // ... for metrics to be collected
 
-      expect(metricValue("cold_entries")).to.eq(totalCold);
-      expect(metricValue("remaining_entries")).to.eq(0);
-      expect(metricValue("incoming_messages")).to.eq(totalInc);
-      expect(metricValue("outgoing_messages")).to.eq(totalOut);
-      expect(metricValue("min_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("med_storage_time_in_seconds")).to.eq(0);
-      expect(metricValue("max_storage_time_in_seconds")).to.eq(0);
-    });
-  });
-});
+      expect(metricValue('cold_entries')).to.eq(totalCold)
+      expect(metricValue('remaining_entries')).to.eq(0)
+      expect(metricValue('incoming_messages')).to.eq(totalInc)
+      expect(metricValue('outgoing_messages')).to.eq(totalOut)
+      expect(metricValue('min_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('med_storage_time_in_seconds')).to.eq(0)
+      expect(metricValue('max_storage_time_in_seconds')).to.eq(0)
+    })
+  })
+})


### PR DESCRIPTION
With unhandled unbound actions now throwing, tests without a dedicated handler for the `call` action of the `ExternalService`, used to simulate an external service to use in `.queued` / `.outboxed`, would throw and mess up the test expectations.