### PR TITLE
chore: `VCAP_SERVICES_FILE_PATH` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This is the default kind in both development and production.
 
 Exports traces and metrics to Dynatrace.
 Hence, a Dynatrace instance is required and the app must be bound to that Dynatrace instance.
+Please note, that for the binding to be resolved, the bound service instance needs to use the tag `dynatrace`, regardless of whether it is a user-provided service instance or not.
 
 Use via `cds.requires.telemetry.kind = 'to-dynatrace'`.
 
@@ -289,12 +290,13 @@ In order to receive OpenTelemetry credentials in the binding to the SAP Cloud Lo
 }
 ```
 
-If you are binding your app to SAP Cloud Logging via a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html), make sure that it has either tag `cloud-logging` or `Cloud Logging`.
+If you are binding your app to SAP Cloud Logging via a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html), make sure that it has the tag `Cloud Logging`.
 
 > Tip: To add the required tag to an existing user-provided service, you can use: 
 > ```
 > cf update-user-provided-service {service-name} -t "cloud-logging"
 > ```
+> For detailed information about binding resolution in CAP, consult [the relevant documentation](https://cap.cloud.sap/docs/node.js/cds-connect#vcap_services).
 
 ### `telemetry-to-jaeger`
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,10 @@ In order to receive OpenTelemetry credentials in the binding to the SAP Cloud Lo
 
 If you are binding your app to SAP Cloud Logging via a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html), make sure that it has either tag `cloud-logging` or `Cloud Logging`.
 
-> Tip: You can use `cf update-user-provided-service {service-name} -t "cloud-logging"` to add the tag to an existing user provided service. 
+> Tip: To add the required tag to an existing user-provided service, you can use: 
+> ```
+> cf update-user-provided-service {service-name} -t "cloud-logging"
+> ```
 
 ### `telemetry-to-jaeger`
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ If you are binding your app to SAP Cloud Logging via a [user-provided service in
 
 > Tip: To add the required tag to an existing user-provided service, you can use: 
 > ```
-> cf update-user-provided-service {service-name} -t "cloud-logging"
+> cf update-user-provided-service {service-name} -t "Cloud Logging"
 > ```
 > For detailed information about binding resolution in CAP, consult [the relevant documentation](https://cap.cloud.sap/docs/node.js/cds-connect#vcap_services).
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ In order to receive OpenTelemetry credentials in the binding to the SAP Cloud Lo
 
 If you are binding your app to SAP Cloud Logging via a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html), make sure that it has either tag `cloud-logging` or `Cloud Logging`.
 
+> Tip: You can use `cf update-user-provided-service {service-name} -t "cloud-logging"` to add the tag to an existing user provided service. 
+
 ### `telemetry-to-jaeger`
 
 Exports traces to Jaeger.

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -40,7 +40,7 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
+    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
     augmentCLCreds(credentials)
     config.url ??= credentials.url
     config.credentials ??= credentials.credentials

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -27,6 +27,8 @@ function _getExporter() {
     credentials
   } = cds.env.requires.telemetry
 
+  cds.log('otel-debug').debug('Configured credentials: ', credentials)
+
   // for kind telemetry-to-otlp based on env vars
   if (metricsExporter === 'env') {
     const cstm_env = getEnvWithoutDefaults()
@@ -48,6 +50,8 @@ function _getExporter() {
     throw new Error(`Unknown metrics exporter "${metricsExporter.class}" in module "${metricsExporter.module}"`)
   const config = { ...(metricsExporter.config || {}) }
 
+  cds.log('otel-debug').debug('Metrics exporter kind:', kind)
+
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
     if (!credentials) throw new Error('No Dynatrace credentials found.')
@@ -63,6 +67,8 @@ function _getExporter() {
   }
 
   if (kind.match(/to-cloud-logging$/)) {
+    cds.log('otel-debug').debug('Getting credentials?', !!credentials)
+
     if (!credentials) credentials = getCredsForCLSAsUPS()
     if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
     augmentCLCreds(credentials)

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -50,7 +50,7 @@ function _getExporter() {
 
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
-    if (!credentials) throw new Error('No Dynatrace credentials found.')
+    if (!credentials) throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
     config.url ??= `${credentials.apiurl}/v2/otlp/v1/metrics`
     config.headers ??= {}
     // credentials.rest_apitoken?.token is deprecated and only supported for compatibility reasons
@@ -64,7 +64,7 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
+    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
     augmentCLCreds(credentials)
     config.url ??= credentials.url
     config.credentials ??= credentials.credentials

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -27,8 +27,6 @@ function _getExporter() {
     credentials
   } = cds.env.requires.telemetry
 
-  cds.log('otel-debug').debug('Configured credentials: ', credentials)
-
   // for kind telemetry-to-otlp based on env vars
   if (metricsExporter === 'env') {
     const cstm_env = getEnvWithoutDefaults()
@@ -50,8 +48,6 @@ function _getExporter() {
     throw new Error(`Unknown metrics exporter "${metricsExporter.class}" in module "${metricsExporter.module}"`)
   const config = { ...(metricsExporter.config || {}) }
 
-  cds.log('otel-debug').debug('Metrics exporter kind:', kind)
-
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
     if (!credentials) throw new Error('No Dynatrace credentials found.')
@@ -67,8 +63,6 @@ function _getExporter() {
   }
 
   if (kind.match(/to-cloud-logging$/)) {
-    cds.log('otel-debug').debug('Getting credentials?', !!credentials)
-
     if (!credentials) credentials = getCredsForCLSAsUPS()
     if (!credentials) throw new Error('No SAP Cloud Logging credentials found.')
     augmentCLCreds(credentials)

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -106,7 +106,7 @@ function _getExporter() {
 
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
-    if (!credentials) throw new Error('No Dynatrace credentials found')
+    if (!credentials) throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
     config.url ??= `${credentials.apiurl}/v2/otlp/v1/traces`
     config.headers ??= {}
     // credentials.rest_apitoken?.token is deprecated and only supported for compatibility reasons
@@ -119,7 +119,7 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found')
+    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
     augmentCLCreds(credentials)
     config.url ??= credentials.url
     config.credentials ??= credentials.credentials

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,11 @@ function getCredsForDTAsUPS() {
   if (!process.env.VCAP_SERVICES) return
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
 
-  // to support connection via user-provided services, APMs requirement is that the instance name contains "dynatrace"
+  // Legacy Compat:
+  // > APMs requirement is that the instance name contains "dynatrace"
+  // > In addition to matching predicate defined in package.json, also support
+  // > - name matching /dynatrace/
+  // ... in case binding info is available from environment variable VCAP_SERVICES
   const dt = vcap['user-provided']?.find(b => b.name.match(/dynatrace/))
   if (dt) return dt.credentials
 }
@@ -118,15 +122,18 @@ function getCredsForCLSAsUPS() {
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
   let ups
 
-  // to support connection via user-provided services, the instance must have either tag "cloud-logging" or "Cloud Logging"
+  // Legacy Compat:
+  // > In addition to matching predicate defined in package.json, also support
+  // > - tag: "cloud-logging"
+  // > - name matching /cloud-logging/
+  // ... in case binding info is available from environment variable VCAP_SERVICES
   ups = vcap['user-provided']?.find(e => e.tags.includes('cloud-logging') || e.tags.includes('Cloud Logging'))
   if (ups) return ups.credentials
 
-  // legacy compat
   ups = vcap['user-provided']?.find(b => b.name.match(/cloud-logging/))
   if (ups) {
     // prettier-ignore
-    LOG._warn && LOG.warn('User-provided service instances of SAP Cloud Logging should have either tag "cloud-logging" or "Cloud Logging"')
+    LOG._warn && LOG.warn('User-provided service instances of SAP Cloud Logging should have the tag "Cloud Logging"')
     return ups.credentials
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,8 @@ function getResource() {
     LOG._info && LOG.info('Unable to require package.json to resolve app name and version due to error:', err)
   }
 
+  // TODO: If we let PKG.name override the VCAP_APPLICATION.name
+  // TODO: We end up with my-app, while the name in the standarad deployment is my-app-srv
   const name = PKG?.name || VCAP_APPLICATION?.name || 'CAP Application'
   const version = PKG?.version || VCAP_APPLICATION?.application_version || '1.0.0'
 
@@ -115,6 +117,9 @@ function getCredsForCLSAsUPS() {
   if (!process.env.VCAP_SERVICES) return
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
   let ups
+
+  LOG.debug('Trying to find credentials for Cloud Logging in VCAP SERVICES')
+  LOG.debug('VCAP SERVICES:', JSON.stringify(vcap, null, 2))
 
   // to support connection via user-provided services, the instance must have either tag "cloud-logging" or "Cloud Logging"
   ups = vcap['user-provided']?.find(e => e.tags.includes('cloud-logging') || e.tags.includes('Cloud Logging'))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,8 +118,8 @@ function getCredsForCLSAsUPS() {
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
   let ups
 
-  LOG.debug('Trying to find credentials for Cloud Logging in VCAP SERVICES')
-  LOG.debug('VCAP SERVICES:', JSON.stringify(vcap, null, 2))
+  cds.log('otel-debug').debug('Trying to find credentials for Cloud Logging in VCAP SERVICES')
+  cds.log('otel-debug').debug('VCAP SERVICES:', JSON.stringify(vcap, null, 2))
 
   // to support connection via user-provided services, the instance must have either tag "cloud-logging" or "Cloud Logging"
   ups = vcap['user-provided']?.find(e => e.tags.includes('cloud-logging') || e.tags.includes('Cloud Logging'))

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,9 +118,6 @@ function getCredsForCLSAsUPS() {
   const vcap = JSON.parse(process.env.VCAP_SERVICES)
   let ups
 
-  cds.log('otel-debug').debug('Trying to find credentials for Cloud Logging in VCAP SERVICES')
-  cds.log('otel-debug').debug('VCAP SERVICES:', JSON.stringify(vcap, null, 2))
-
   // to support connection via user-provided services, the instance must have either tag "cloud-logging" or "Cloud Logging"
   ups = vcap['user-provided']?.find(e => e.tags.includes('cloud-logging') || e.tags.includes('Cloud Logging'))
   if (ups) return ups.credentials

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,8 +40,6 @@ function getResource() {
     LOG._info && LOG.info('Unable to require package.json to resolve app name and version due to error:', err)
   }
 
-  // TODO: If we let PKG.name override the VCAP_APPLICATION.name
-  // TODO: We end up with my-app, while the name in the standarad deployment is my-app-srv
   const name = PKG?.name || VCAP_APPLICATION?.name || 'CAP Application'
   const version = PKG?.version || VCAP_APPLICATION?.application_version || '1.0.0'
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         },
         "telemetry-to-cloud-logging": {
           "vcap": {
-            "label": "cloud-logging"
+            "tag": "Cloud Logging"
           },
           "tracing": {
             "exporter": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         },
         "telemetry-to-dynatrace": {
           "vcap": {
-            "label": "dynatrace"
+            "tag": "dynatrace"
           },
           "tracing": {
             "exporter": {


### PR DESCRIPTION
Relates to: https://github.com/cap-js/telemetry/issues/389

### Problem

Currently, when using `VCAP_SERVICES_FILE_PATH` via [CF feature flag `file-based-vcap-services`](https://docs.cloudfoundry.org/devguide/services/application-binding.html#file-based-vcap-services), a user provided service instance of Cloud Logging (or dynatrace) will not be correctly resolved. The relevant local util: 

https://github.com/cap-js/telemetry/blob/ae3e619b7cf206779830acf4596153663b98b1d9/lib/utils.js#L114-L130

... is not equipped to resolve binding information from anywhere but the `VCAP_SERVICES` env variable. 

### Fix

However, the existing `cds.env` is - given we provide the correct matching predicate in `cds.requires.telemetry.vcap`. 

Since, a non-user-provided instance comes tagged with `Cloud Logging` by default, we should update our default matching predicate in `package.json` accordingly and get that much closer to what's described in the [cloud logging docs](https://help.sap.com/docs/cloud-logging/cloud-logging/ingest-via-opentelemetry-api-endpoint#:~:text=Using%20user%2Dprovided%20Services). This PR suggests the required changes. 

In case we can use the new greedy matchers, we could extend rather than update our current matchers: https://github.com/cap-js/telemetry/pull/407

<details>
<summary><h3>Less Intrusive Alternative</h3></summary>

In case we do not want to update our default matching predicates, we should update the `README` with the config section, that will cause `label` to be ignored during matching:

Currently, we use:

https://github.com/cap-js/telemetry/blob/ae3e619b7cf206779830acf4596153663b98b1d9/package.json#L126-L128

... but instruct integrating developers to add `cloud-logging` to the tags of the user provided service, rather than a label. It looks like the label of user provided services will always be `user-provided`. Matching of `user-provided` services works out, if the integrating developer updates their local config like: 

```json
{
  "cds": {
    "requires": {
      "telemetry": {
        "vcap": {
          "label": false,
          "tag": "cloud-logging"
        }
      }
    }
  }
}
```
</details>