### PR TITLE
fix: prefer `VCAP_APPLICATION.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.7.0 - tbd
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Prefer `VCAP_APPLICATION.name` over `name` in `package.json` for app name resolution
+
+### Removed
+
 ## Version 1.6.0 - 2025-12-16
 
 ### Added

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,7 +61,7 @@ function getResource() {
   if (VCAP_APPLICATION) {
     attributes['sap.cf.source_id'] = VCAP_APPLICATION.application_id
     attributes['sap.cf.app_id'] = VCAP_APPLICATION.application_id
-    attributes['sap.cf.app_name'] = name
+    attributes['sap.cf.app_name'] = VCAP_APPLICATION.name
     attributes['sap.cf.space_id'] = VCAP_APPLICATION.space_id
     attributes['sap.cf.space_name'] = VCAP_APPLICATION.space_name
     attributes['sap.cf.org_id'] = VCAP_APPLICATION.organization_id

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ function getResource() {
     LOG._info && LOG.info('Unable to require package.json to resolve app name and version due to error:', err)
   }
 
-  const name = PKG?.name || VCAP_APPLICATION?.name || 'CAP Application'
+  const name =  VCAP_APPLICATION?.name || PKG?.name || 'CAP Application'
   const version = PKG?.version || VCAP_APPLICATION?.application_version || '1.0.0'
 
   const attributes = {}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ function getResource() {
     LOG._info && LOG.info('Unable to require package.json to resolve app name and version due to error:', err)
   }
 
-  const name =  VCAP_APPLICATION?.name || PKG?.name || 'CAP Application'
+  const name = VCAP_APPLICATION?.name || PKG?.name || 'CAP Application'
   const version = PKG?.version || VCAP_APPLICATION?.application_version || '1.0.0'
 
   const attributes = {}


### PR DESCRIPTION
# Prioritize `VCAP_APPLICATION.name` Over `package.json` for App Name Resolution

### Bug Fix

🐛 Adjusted the application name resolution logic in `getResource()` to prefer `VCAP_APPLICATION.name` over the `package.json` name when running in a Cloud Foundry environment.

### Changes

* `lib/utils.js`:
  - **Name resolution order**: Swapped the priority so `VCAP_APPLICATION?.name` is checked before `PKG?.name` when determining the `name` variable used for telemetry attributes. This ensures the CF application name takes precedence over the local package name.
  - **`sap.cf.app_name` attribute**: Changed from using the resolved `name` variable (which could fall back to `PKG?.name`) to always using `VCAP_APPLICATION.name` directly. This guarantees the Cloud Foundry-specific attribute reflects the actual CF app name rather than a potential fallback value.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `27f1a010-f011-445b-b588-6bd73118c1b6`
- Event Trigger: `pull_request.ready_for_review`
- File Content Strategy: Full file content
</details>
