### PR TITLE
chore: guard against cds10 until prepped

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "@opentelemetry/semantic-conventions": "^1.36"
   },
   "peerDependencies": {
-    "@sap/cds": ">=8"
+    "@sap/cds": "^8 || ^9"
   },
   "devDependencies": {
-    "@cap-js/cds-test": ">=0",
-    "@cap-js/sqlite": ">=1",
+    "@cap-js/cds-test": "^0",
+    "@cap-js/sqlite": "^1 || ^2",
     "@cap-js/telemetry": "file:.",
     "@dynatrace/oneagent-sdk": "^1.5.0",
     "@grpc/grpc-js": "^1.9.14",
@@ -43,7 +43,7 @@
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
     "@opentelemetry/host-metrics": "^0.36.0",
     "@opentelemetry/instrumentation-runtime-node": "^0.17.0",
-    "@sap/cds-mtxs": ">=2",
+    "@sap/cds-mtxs": "^2 || ^3",
     "axios": "^1.6.7",
     "chai": "^4.4.1",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
# Guard Against CDS 10 by Restricting Peer Dependency Version Range

### Chore

🔧 Updated the `@sap/cds` peer dependency version range in `package.json` to explicitly exclude CDS version 10 until the package is prepared to support it. Related dev dependency version ranges were also tightened for consistency.

### Changes

* `package.json`:
  - Changed `@sap/cds` peer dependency from `>=8` to `^8 || ^9`, preventing accidental resolution to CDS 10.
  - Tightened `@cap-js/cds-test` dev dependency from `>=0` to `^0`.
  - Tightened `@cap-js/sqlite` dev dependency from `>=1` to `^1 || ^2`.
  - Updated `@sap/cds-mtxs` dev dependency from `>=2` to `^2 || ^3`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.33`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `d038cf21-0707-45ec-b548-214367285b6b`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
