### PR TITLE
chore: reduce wait times

### DIFF
--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -78,7 +78,7 @@ describe('queue metrics for multi tenant service', () => {
         GET('/odata/v4/proxy/proxyCallToExternalServiceOne', user[T2])
       ])
 
-      await wait(300) // Wait for metrics to be collected
+      await wait(150) // Wait for metrics to be collected
 
       expect(metricValue(T1, 'cold_entries')).to.eq(0)
       expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])
@@ -138,7 +138,7 @@ describe('queue metrics for multi tenant service', () => {
       if (timeAfterFirstRetry - timeOfInitialCall < 1000) {
         await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall))
       }
-      await wait(300) // ... for metrics to be collected
+      await wait(150) // ... for metrics to be collected
 
       expect(metricValue(T1, 'cold_entries')).to.eq(0)
       expect(metricValue(T1, 'incoming_messages')).to.eq(totalInc[T1])

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -86,7 +86,7 @@ describe('queue metrics for single tenant service', () => {
     test('metrics are collected', async () => {
       await GET('/odata/v4/proxy/proxyCallToExternalServiceOne', admin)
 
-      await wait(300) // Wait for metrics to be collected
+      await wait(150) // Wait for metrics to be collected
 
       expect(metricValue('cold_entries', E1)).to.eq(0)
       expect(metricValue('remaining_entries', E1)).to.eq(0)
@@ -99,7 +99,7 @@ describe('queue metrics for single tenant service', () => {
 
       await GET('/odata/v4/proxy/proxyCallToExternalServiceTwo', admin)
 
-      await wait(300) // Wait for metrics to be collected
+      await wait(150) // Wait for metrics to be collected
 
       expect(metricValue('cold_entries', E2)).to.eq(0)
       expect(metricValue('remaining_entries', E2)).to.eq(0)
@@ -149,7 +149,7 @@ describe('queue metrics for single tenant service', () => {
       await GET('/odata/v4/proxy/proxyCallToExternalServiceOne', admin)
       await GET('/odata/v4/proxy/proxyCallToExternalServiceTwo', admin)
 
-      await wait(300) // ... for metrics to be collected
+      await wait(150) // ... for metrics to be collected
       expect(currentRetryCount[E1]).to.eq(1)
 
       expect(metricValue('cold_entries', E1)).to.eq(0)
@@ -183,7 +183,7 @@ describe('queue metrics for single tenant service', () => {
         await wait(1000 - (timeAfterFirstRetry - timeOfInitialCall))
       }
 
-      await wait(300) // ... for metrics to be collected again
+      await wait(150) // ... for metrics to be collected again
 
       expect(metricValue('cold_entries', E1)).to.eq(0)
       expect(metricValue('remaining_entries', E1)).to.eq(1)
@@ -205,7 +205,7 @@ describe('queue metrics for single tenant service', () => {
 
       // Wait for the second retry to be initiated
       while (currentRetryCount[E1] < 3) await wait(100)
-      await wait(300) // ... for the retry to be processed and metrics to be collected
+      await wait(150) // ... for the retry to be processed and metrics to be collected
       expect(currentRetryCount[E1]).to.eq(3)
       expect(currentRetryCount[E2]).to.eq(3)
 
@@ -258,7 +258,7 @@ describe('queue metrics for single tenant service', () => {
       await GET('/odata/v4/proxy/proxyCallToExternalServiceOne', admin)
       await GET('/odata/v4/proxy/proxyCallToExternalServiceTwo', admin)
 
-      await wait(300) // ... for metrics to be collected
+      await wait(150) // ... for metrics to be collected
 
       expect(metricValue('cold_entries', E1)).to.eq(1)
       expect(metricValue('remaining_entries', E1)).to.eq(0)


### PR DESCRIPTION
# Reduce Test Wait Times for Metrics Collection

### Chore

⚡ Reduced hardcoded wait times in metrics-related tests from `300ms` to `150ms`, cutting unnecessary delays in the test suite.

### Changes

* `test/metrics-outbox-multitenant.test.js`: Reduced all `wait(300)` calls used for metrics collection to `wait(150)`.
* `test/metrics-outbox.test.js`: Reduced all `wait(300)` calls used for metrics collection to `wait(150)`, across multiple test cases covering immediate success, retry scenarios, and cold entry observation.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.33`

- Correlation ID: `f28eb04d-3218-4c2b-a550-fd6dd09fc04b`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
