### PR TITLE
Improve CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    cooldown:
+      default-days: 1
     groups:
       prod-dependencies:
         dependency-type: 'production'
@@ -20,3 +22,10 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       - run: npm i
       - run: npm run lint
@@ -25,6 +29,10 @@ jobs:
         node-version: [22.x, 20.x]
         cds-version: [9, 8]
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/hana.yml
+++ b/.github/workflows/hana.yml
@@ -22,6 +22,10 @@ jobs:
       HANA_DRIVER: ${{ matrix.hana-driver }}
       HANA_PROM: ${{ matrix.hana-prom }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - uses: cap-js/.github/.github/actions/hana-hdi-container@main

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -13,6 +13,10 @@ jobs:
   label_issues:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - run: gh issue edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Add dependabot for NPM and GitHub Actions. Weekly checks with 1 day cooldown to avoid pushing freshly compromised deps.

Add [Harden Runner](https://github.com/step-security/harden-runner) to all GitHub Actions to monitor the processes.