### PR TITLE
chore: CI runs with node 22 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 20.x]
+        node-version: [24.x, 22.x]
         cds-version: [9, 8]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Update CI Node.js Versions to 22 and 24

### Chore

🔧 Updated the CI pipeline to test against Node.js versions 22 and 24, replacing the previously used versions 20 and 22.

### Changes

* `.github/workflows/ci.yml`: Updated the `node-version` matrix from `[22.x, 20.x]` to `[24.x, 22.x]`, dropping Node.js 20 support and adding Node.js 24 to the test matrix.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `1be99873-b0ad-46ce-9776-4eb083e7397b`
</details>
