### PR TITLE
fix: export all data points to console

### DIFF
--- a/lib/exporter/ConsoleMetricExporter.js
+++ b/lib/exporter/ConsoleMetricExporter.js
@@ -73,7 +73,12 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
           for (const dp of metric.dataPoints) {
             const t = dp.attributes['sap.tenancy.tenant_id']
             collector[t] ??= {}
-            collector[t][name] = collector !== other ? dp.value : dp
+            if (collector === other) {
+              collector[t][name] ??= []
+              collector[t][name].push(dp)
+            } else {
+              collector[t][name] = dp.value
+            }
           }
         }
 
@@ -114,7 +119,7 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
         // export other metrics
         for (const tenant of Object.keys(other)) {
           for (const [k, v] of Object.entries(other[tenant])) {
-            LOG.info(`${k}${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}: ${inspect(v)}`)
+            LOG.info(`${k}${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}: ${inspect(v.length === 1 ? v[0] : v)}`)
           }
         }
       }

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -22,4 +22,16 @@ describe('metrics', () => {
     expect(log.output).to.match(/process/i)
     expect(log.output).not.to.match(/network/i)
   })
+
+  test('other metrics with multiple datapoints are logged as array', async () => {
+    const { status } = await GET('/odata/v4/admin/Books', admin)
+    expect(status).to.equal(200)
+
+    await wait(200)
+
+    // nodejs.eventloop.time has multiple datapoints (active + idle) → logged as array
+    expect(log.output).to.match(/nodejs\.eventloop\.time: \[/)
+    // nodejs.eventloop.utilization has single datapoint → logged unwrapped (not as array)
+    expect(log.output).to.match(/nodejs\.eventloop\.utilization: \{/)
+  })
 })


### PR DESCRIPTION
# Fix Console Exporter to Export All DataPoints

🐛 **Bug Fix:** The console metric exporter was only writing the last data point to the console when a metric had multiple data points. This PR fixes the issue by collecting all data points and logging them correctly.

### Changes

* `lib/exporter/ConsoleMetricExporter.js`: Updated the "other" metrics collection logic to accumulate all data points into an array instead of overwriting with each iteration. When logging, single-item arrays are unwrapped for cleaner output, while multiple data points are logged as an array.
* `test/metrics.test.js`: Added a test case to verify that metrics with multiple data points (e.g., `nodejs.eventloop.time`) are logged as an array, while metrics with a single data point (e.g., `nodejs.eventloop.utilization`) are logged unwrapped.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- Correlation ID: `5844a5e6-666e-437e-88db-b2bc30fcb730`
- Event Trigger: `issue_comment.edited`
</details>
