### PR TITLE
chore: NPM_CONFIG_IGNORE_SCRIPTS instead of .npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ permissions:
 on:
   workflow_dispatch:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: true
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true


### PR DESCRIPTION
# Replace `.npmrc` with `NPM_CONFIG_IGNORE_SCRIPTS` Environment Variable

### Chore

🔧 Replaced the `.npmrc` file approach for ignoring npm scripts with the `NPM_CONFIG_IGNORE_SCRIPTS=true` environment variable set directly in the GitHub Actions workflows.

### Changes

* `.github/workflows/ci.yml`: Added a global `env` block with `NPM_CONFIG_IGNORE_SCRIPTS: true` to prevent npm scripts from running during CI.
* `.github/workflows/release.yml`: Added the same `NPM_CONFIG_IGNORE_SCRIPTS: true` environment variable to the release workflow.
* `.npmrc`: Removed, as its functionality is now handled via the environment variable in the workflows.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Correlation ID: `f956afa4-b791-4408-9f2c-ec3ba414d705`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
</details>
