### PR TITLE
fix: adapt queue metrics to CDS v10 scheduling changes

### DIFF
--- a/lib/metrics/queue.js
+++ b/lib/metrics/queue.js
@@ -193,8 +193,8 @@ module.exports = () => {
 
       const queuedServiceName = JSON.parse(createTaskReq.data.msg || '{}').service ?? createTaskReq.data.target
       if (queuedServiceName === 'scheduling') return // skip internal scheduler flush markers
-      const targetedService = cds.services[queuedServiceName]
 
+      const targetedService = cds.services[queuedServiceName]
       if (!targetedService) {
         LOG.debug('Skipping registration of queue metrics collection for unknown service:', queuedServiceName)
         return

--- a/lib/metrics/queue.js
+++ b/lib/metrics/queue.js
@@ -156,7 +156,7 @@ function tenantQueueStastics(statistics, tenant, queuedServiceName) {
   cds.spawn(privileged_context, async () => {
     const queueEntity = cds.model.definitions[PERSISTENT_QUEUE_DB_NAME]
     // REVISIT: stable access to queue config
-    const maxAttempts = cds.queued(cds.services[queuedServiceName]).outboxed.maxAttempts ?? 20
+    const maxAttempts = cds.queued(cds.services[queuedServiceName]).outboxed.maxAttempts ?? 10
     const latestStatistics = await collectLatestQueueInfo(queueEntity, queuedServiceName, maxAttempts)
     Object.assign(statistics[tenant][queuedServiceName], latestStatistics)
   })
@@ -187,10 +187,12 @@ module.exports = () => {
     initQueueObservation(statistics)
 
     // Register service when it's first found to be the target of an queued message
-    cds.db.after('CREATE', queueEntity, async (_, createTaskReq) => {
+    // CDS >=10 (scheduling:true) uses UPSERT via Scheduler.scheduleTask; CDS 9 uses INSERT (fires as CREATE)
+    cds.db.after(['CREATE', 'UPSERT'], queueEntity, async (_, createTaskReq) => {
       const tenant = cds.context?.tenant
 
       const queuedServiceName = JSON.parse(createTaskReq.data.msg || '{}').service ?? createTaskReq.data.target
+      if (queuedServiceName === 'scheduling') return // skip internal scheduler flush markers
       const targetedService = cds.services[queuedServiceName]
 
       if (!targetedService) {
@@ -200,7 +202,10 @@ module.exports = () => {
 
       // Increase the `incoming_messages` counter each time ...
       // > a new task is created in the persistent queue
-      tenantQueueStastics(statistics, tenant, queuedServiceName).incomingMessages += 1
+      // In CDS >=10 (scheduling:true), retries also fire UPSERT with attempts > 0 — skip those
+      if (createTaskReq.data.attempts == null) {
+        tenantQueueStastics(statistics, tenant, queuedServiceName).incomingMessages += 1
+      }
 
       if (!registeredServices.has(queuedServiceName)) {
         registeredServices.add(queuedServiceName)

--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -45,9 +45,6 @@
         "_kind": "file-based-messaging",
         "file": "../msg-box"
       },
-      "db": {
-        "pool": { "max": 1 }
-      },
       "_outbox": {
         "kind": "persistent-outbox"
       },

--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -45,6 +45,9 @@
         "_kind": "file-based-messaging",
         "file": "../msg-box"
       },
+      "db": {
+        "pool": { "max": 1 }
+      },
       "_outbox": {
         "kind": "persistent-outbox"
       },


### PR DESCRIPTION
CDS v10 enables scheduling by default, which changes how outbox messages are written and processed:

- Scheduler.scheduleTask now uses UPSERT instead of INSERT, so db.after 'CREATE' never fires for new messages; listen for both 'CREATE' and 'UPSERT' to stay compatible with CDS 9 and 10
- Scheduler also UPSERTs internal flush markers (service:'scheduling'); skip these to avoid counting them as incoming messages
- Retries fire UPSERT with attempts>0; guard incomingMessages increment to only count initial inserts (attempts==null)
- Update maxAttempts fallback from 20 to 10 (CDS v10 default)

Also add db.pool.max:1 to the test bookshop config: @cap-js/sqlite@3 switched from better-sqlite3 to node:sqlite where each :memory: connection is an isolated database, so without a pool cap of 1 the deploy and queue processor can land on different connections and the table created by deploy is invisible to the processor.