### PR TITLE
chore: switch off hana jobs by default

### DIFF
--- a/.github/workflows/hana.yml
+++ b/.github/workflows/hana.yml
@@ -5,10 +5,10 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # push:
+  #  branches: [main]
+  # pull_request:
+  #  branches: [main]
 
 jobs:
   hana:


### PR DESCRIPTION
# Disable Automatic HANA Workflow Triggers by Default

### Chore

🔧 Disabled the automatic `push` and `pull_request` triggers for the HANA GitHub Actions workflow, leaving only manual (`workflow_dispatch`) execution enabled.

### Changes

* `.github/workflows/hana.yml`: Commented out the `push` and `pull_request` event triggers on the `main` branch. The workflow can now only be triggered manually via `workflow_dispatch`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `bd22d4d2-ae09-40ab-93a0-f11ba8d5949e`
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
