### PR TITLE
test: use native fetch in cds oq

### DIFF
--- a/test/tracing-attributes.test.js
+++ b/test/tracing-attributes.test.js
@@ -1,3 +1,6 @@
+// REVISIT: use native fetch in cds oq
+process.env.cds_remote_native__fetch = 'true'
+
 const cds = require('@sap/cds')
 const { expect, data } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-attributes')
 const http = require('http')


### PR DESCRIPTION
in cds oq, we have cloud-sdk → it is preferred over native fetch
the test added in https://github.com/cap-js/telemetry/pull/425 only works when native fetch is used