### PR TITLE
fix: fall back to standalone telemetry setup when xotel-agent-ext-js lacks CALM composite APIs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation')
 const tracing = require('./tracing')
 const metrics = require('./metrics')
 const logging = require('./logging')
-const { getDiagLogLevel, getResource, hasDependency, _require } = require('./utils')
+const { getDiagLogLevel, getResource, hasCalmSupport, _require } = require('./utils')
 
 function _getInstrumentations() {
   const _instrumentations = cds.env.requires.telemetry.instrumentations
@@ -117,4 +117,4 @@ function setup_with_calm() {
   if (cds.env.requires.telemetry.logging) logging()
 }
 
-module.exports = hasDependency('@sap/xotel-agent-ext-js') ? setup_with_calm : setup_standalone
+module.exports = hasCalmSupport() ? setup_with_calm : setup_standalone

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -168,6 +168,31 @@ function hasDependency(name) {
   return !!PKG.dependencies[name]
 }
 
+// CALM integration via @sap/xotel-agent-ext-js requires the composite
+// span processor / metric reader / log record processor APIs. Older
+// versions of that package don't export them, so only opt into the
+// CALM setup path if they are actually available.
+let _calmSupport
+function hasCalmSupport() {
+  if (_calmSupport !== undefined) return _calmSupport
+  if (!hasDependency('@sap/xotel-agent-ext-js')) return (_calmSupport = false)
+  try {
+    const xotel = require('@sap/xotel-agent-ext-js')
+    _calmSupport =
+      typeof xotel.getCompositeSpanProcessor === 'function' &&
+      typeof xotel.getCompositeMetricReader === 'function' &&
+      typeof xotel.getCompositeLogRecordProcessor === 'function'
+  } catch (err) {
+    LOG._info && LOG.info('Unable to require @sap/xotel-agent-ext-js to check for CALM support due to error:', err)
+    _calmSupport = false
+  }
+  if (!_calmSupport)
+    LOG.warn(
+      '@sap/xotel-agent-ext-js found, but it does not support the composite delegate APIs required for CALM integration; falling back to standalone telemetry setup'
+    )
+  return _calmSupport
+}
+
 const now = Date.now()
 const hrTimeInMS = Number(`${hrTimeToMilliseconds(process.hrtime())}`.split('.')[0])
 const diff = now - hrTimeInMS
@@ -204,6 +229,7 @@ module.exports = {
   getCredsForCLSAsUPS,
   augmentCLCreds,
   hasDependency,
+  hasCalmSupport,
   _hrnow,
   _require
 }


### PR DESCRIPTION
## Problem

`hasDependency('@sap/xotel-agent-ext-js')` alone is used to decide whether to use the CALM integration path (`setup_with_calm()`). This assumes any version of `@sap/xotel-agent-ext-js` exposes the composite delegate APIs (`getCompositeSpanProcessor`, `getCompositeMetricReader`, `getCompositeLogRecordProcessor`).

Versions of `@sap/xotel-agent-ext-js` that don't export these functions cause `@cap-js/telemetry` to throw at boot:

\`\`\`
TypeError: getCompositeSpanProcessor is not a function
    at module.exports (lib/tracing/index.js:179:7)
    at setup_with_calm (lib/index.js:115:3)
    at cds-plugin.js:15:19
\`\`\`

The error is caught and re-thrown, so the process doesn't crash, but tracing/metrics/logging integration silently breaks and boot logs are flooded with errors.

## Fix

Add `hasCalmSupport()` in `lib/utils.js`, which checks not only that `@sap/xotel-agent-ext-js` is a dependency, but that it actually exports the three composite delegate functions required for the CALM integration. `lib/index.js` now uses this instead of the raw dependency check, falling back to `setup_standalone()` when the required APIs aren't available.

## Testing

- \`npx eslint lib/index.js lib/utils.js --max-warnings=0\` passes
- \`npx jest --silent\` — all 11 runnable test suites pass (39/39 non-skipped tests)

Fixes #459