### PR TITLE
ci: pin GitHub Actions via commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: npm i
       - run: npm run lint
   test:
@@ -28,9 +28,9 @@ jobs:
         node-version: [24.x, 22.x]
         cds-version: [10, 9]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}

--- a/.github/workflows/hana.yml
+++ b/.github/workflows/hana.yml
@@ -23,9 +23,9 @@ jobs:
       HANA_DRIVER: ${{ matrix.hana-driver }}
       HANA_PROM: ${{ matrix.hana-prom }}
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-node@v6.4.0
-      - uses: cap-js/.github/.github/actions/hana-hdi-container@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: cap-js/.github/.github/actions/hana-hdi-container@2c44e9c222ecccde07efa5fb607855c527c08e61 # main
         with:
           instance-prefix: telemetry
           config-path: test/bookshop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -29,14 +29,14 @@ jobs:
           npm run test
       - name: get version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
       - name: parse changelog
         id: parse-changelog
-        uses: schwma/parse-changelog-action@v1.2.0
+        uses: schwma/parse-changelog-action@1c2b2005ccf594cc3a45d33c10af4ab924d3a1c5 # v1.2.0
         with:
           version: '${{ steps.package-version.outputs.current-version }}'
       - name: create a GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: 'v${{ steps.package-version.outputs.current-version }}'
           body: '${{ steps.parse-changelog.outputs.body }}'


### PR DESCRIPTION
Pin all third-party GitHub Actions to full commit SHAs (with version comments) for supply-chain security, following the approach in cap-js/advanced-event-mesh#76.

Each SHA was verified against GitHub's API for the tag it references.

### Changes

**ci.yml**
- `actions/checkout@v7.0.0` → `@9c091bb` (2×)
- `actions/setup-node@v6.4.0` → `@48b55a0`

**hana.yml**
- `actions/checkout@v7.0.0` → `@9c091bb`
- `actions/setup-node@v6.4.0` → `@48b55a0`
- `cap-js/.github/.github/actions/hana-hdi-container@main` → `@2c44e9c`

**release.yml**
- `actions/checkout@v7.0.0` → `@9c091bb`
- `actions/setup-node@v6.4.0` → `@48b55a0`
- `martinbeentjes/npm-get-version-action@v1.3.1` → `@3cf2730`
- `schwma/parse-changelog-action@v1.2.0` → `@1c2b200`
- `ncipollo/release-action@v1` → `@339a818` (# v1.21.0)

> Note: `cap-js/.github` was previously on `@main` (a moving branch); pinned to the current tip SHA. Happy to revert to `@main` if auto-updating is preferred for this internal action.