### PR TITLE
chore: prep 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 2.1.0 - tbd
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## Version 2.0.1 - 2026-07-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/telemetry",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "CDS plugin providing observability features, incl. automatic OpenTelemetry instrumentation.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare `develop` for the next minor release.

- bump version `2.0.1` → `2.1.0`
- add `## Version 2.1.0 - tbd` changelog skeleton (Added / Changed / Fixed)

Feature PRs merging into `develop` add their bullet under this section; the date is set when `develop` → `main` is promoted.