### PR TITLE
ci: run on pull requests to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 env:
   NPM_CONFIG_IGNORE_SCRIPTS: true


### PR DESCRIPTION
Add `develop` to the CI workflow's `push` and `pull_request` branch triggers so PRs into `develop` (the new integration branch) get lint + the test matrix.

`main` triggers unchanged. HANA remains `workflow_dispatch`-only.