### PR TITLE
chore: adopt prettier for code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm i
       - run: npm run lint
+      - run: npm run format:check
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Dependencies and generated files
+node_modules
+package-lock.json
+CHANGELOG.md
+
+# Excluded: removed by the jest -> vitest migration (chore/vitest); do not reformat to avoid merge conflicts
+jest.config.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 We use GitHub to manage reviews of pull requests.
 
-* If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
+- If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
 
-* Before implementing your change, create an issue that describes the problem you would like to solve or the code that should be enhanced. Please note that you are willing to work on that issue.
+- Before implementing your change, create an issue that describes the problem you would like to solve or the code that should be enhanced. Please note that you are willing to work on that issue.
 
-* The team will review the issue and decide whether it should be implemented as a pull request. In that case, they will assign the issue to you. If the team decides against picking up the issue, the team will post a comment with an explanation.
+- The team will review the issue and decide whether it should be implemented as a pull request. In that case, they will assign the issue to you. If the team decides against picking up the issue, the team will post a comment with an explanation.
 
 ## Steps to Contribute
 
@@ -28,11 +28,11 @@ You are welcome to contribute code in order to fix a bug or to implement a new f
 
 The following rule governs code contributions:
 
-* Contributions must be licensed under the [Apache 2.0 License](./LICENSE)
-* Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
+- Contributions must be licensed under the [Apache 2.0 License](./LICENSE)
+- Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
 
 ## Issues and Planning
 
-* We use GitHub issues to track bugs and enhancement requests.
+- We use GitHub issues to track bugs and enhancement requests.
 
-* Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.
+- Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/cap-js/telemetry)](https://api.reuse.software/info/github.com/cap-js/telemetry)
 
-
-
 ## About This Project
 
 `@cap-js/telemetry` is a CDS plugin providing observability features, including [automatic OpenTelemetry instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic).
 
 Documentation can be found at [cap.cloud.sap](https://cap.cloud.sap/docs) and [opentelemetry.io](https://opentelemetry.io/docs).
-
-
 
 ## Table of Contents
 
@@ -41,20 +37,16 @@ Documentation can be found at [cap.cloud.sap](https://cap.cloud.sap/docs) and [o
 - [Code of Conduct](#code-of-conduct)
 - [Licensing](#licensing)
 
-
-
 ## Requirements
 
 See [Getting Started](https://cap.cloud.sap/docs/get-started) on how to jumpstart your development and grow as you go with SAP Cloud Application Programming Model.
-
-
 
 ## Setup
 
 Simply add `@cap-js/telemetry` to your dependencies via `npm add @cap-js/telemetry` and you will find telemetry output written to the console like so:
 
 ```
-[odata] - GET /odata/v4/processor/Incidents 
+[odata] - GET /odata/v4/processor/Incidents
 [telemetry] - elapsed times:
     0.00 →   2.85 =   2.85 ms  GET /odata/v4/processor/Incidents
     0.47 →   1.24 =   0.76 ms    ProcessorService - READ ProcessorService.Incidents
@@ -73,15 +65,12 @@ The plugin can be disabled by setting environment variable `NO_TELEMETRY` to som
 
 Database tracing is limited to [@cap-js/cds-dbs](https://github.com/cap-js/cds-dbs)-based databases, such as [@cap-js/sqlite](https://www.npmjs.com/package/@cap-js/sqlite) and [@cap-js/hana](https://www.npmjs.com/package/@cap-js/hana).
 
-
-
 ## Telemetry Signals
 
 There are three categories of telemetry data, also referred to as _signals_.
 The following briefly describes, how each is addressed in `@cap-js/telemetry`.
 
 For more information on signals in general, please refer to https://opentelemetry.io/docs/concepts/signals.
-
 
 ### Traces
 
@@ -97,13 +86,12 @@ An example trace printed to the console can be found in [`telemetry-to-console`]
 In environments where Dynatrace OneAgent is installed (e.g., SAP BTP CF), no OpenTelemetry exporter is needed to transport the traces to Dynatrace.
 `@cap-js/telemetry` recognizes this and ignores any exporter config if the predefined kind [`telemetry-to-dynatrace`](#telemetry-to-dynatrace) is used.
 
-
 ### Metrics
 
 Metrics are "measurements captured at runtime", which help you understand your app's health and performance.
 
-The `@cap-js/telemetry` enables the observation of some metrics out of the box. 
-These include generic host metrics collected by [`@opentelemetry/instrumentation-host-metrics`](https://www.npmjs.com/package/@opentelemetry/instrumentation-host-metrics) (if the package is found in the app's dependencies), 
+The `@cap-js/telemetry` enables the observation of some metrics out of the box.
+These include generic host metrics collected by [`@opentelemetry/instrumentation-host-metrics`](https://www.npmjs.com/package/@opentelemetry/instrumentation-host-metrics) (if the package is found in the app's dependencies),
 metrics regarding the app's database pool, namely the [pool info](https://www.npmjs.com/package/generic-pool#pool-info) statistics of `generic-pool`,
 as well as metrics regarding [CAP's Persistent Queue](https://cap.cloud.sap/docs/node.js/queue#persistent-queue).
 
@@ -153,12 +141,13 @@ Further, `queue` metrics are only available when using `@sap/cds >= 9`.
 ```
 [telemetry] - queue:
      cold | remaining | min storage time | med storage time | max storage time | incoming | outgoing
-        2 |        32 |                2 |               16 |              128 |      256 |      512 
+        2 |        32 |                2 |               16 |              128 |      256 |      512
 ```
 
 #### Custom Metrics
 
 Finally, custom metrics can be added as shown in the following example (tenant-aware request counting):
+
 ```js
 // server.js
 
@@ -178,11 +167,11 @@ cds.on('listening', () => {
 module.exports = cds.server
 ```
 
-
 ### Logs
 
 Exporting logs via OpenTelemetry is supported as an experimental opt-in feature.
 Enable it by adding section `logging` to `cds.requires.telemetry` as follows (using `grpc` as an example):
+
 ```json
 "logging": {
   "exporter": {
@@ -191,17 +180,15 @@ Enable it by adding section `logging` to `cds.requires.telemetry` as follows (us
   }
 }
 ```
+
 `cds.log()`'s custom fields configuration for SAP Cloud Logging determines the additional attributes added to the `LogRecord`.
 See [`cds.log()` - Custom Fields](https://cap.cloud.sap/docs/node.js/cds-log#custom-fields) for details.
 
 Please note that in order for logs to be exported via OpenTelemetry, `cds.log()`'s JSON log formatter must be active, which is the default in production but not in development.
 
-
-
 ## Predefined Kinds
 
 There are five predefined kinds as follows:
-
 
 ### `telemetry-to-console`
 
@@ -209,7 +196,6 @@ Prints traces and metrics to the console as previously depicted (traces in [Setu
 
 No additional dependencies are needed.
 This is the default kind in both development and production.
-
 
 ### `telemetry-to-dynatrace`
 
@@ -219,6 +205,7 @@ Hence, a Dynatrace instance is required and the app must be bound to that Dynatr
 Use via `cds.requires.telemetry.kind = 'to-dynatrace'`.
 
 Required additional dependencies:
+
 - `@opentelemetry/exporter-trace-otlp-proto` (optional, see [Leveraging Dynatrace OneAgent](#leveraging-dynatrace-oneagent))
 - `@opentelemetry/exporter-metrics-otlp-proto`
 
@@ -226,6 +213,7 @@ The necessary scopes for exporting traces (`openTelemetryTrace.ingest`) and metr
 This can be done via parameterizing the binding to a "managed service instance" (i.e., not a user-provided service instance) as follows.
 
 Excerpt from example mta.yaml:
+
 ```yaml
 requires:
   - name: my-dynatrace-instance
@@ -241,12 +229,13 @@ requires:
 In the user-provided service case, you'll need to generate a token in Dynatrace with the necessary scopes, add it to the credentials of the user-provided service, and configure `cds.requires.telemetry.token_name` if the token's key in the credentials object is not `ingest_apitoken`.
 
 In Dynatrace itself, you need to ensure that the following two features are enabled:
+
 1. OpenTelemetry Node.js Instrumentation agent support:
-    - From the Dynatrace menu, go to Settings > Preferences > OneAgent features.
-    - Find and turn on OpenTelemetry Node.js Instrumentation agent support.
+   - From the Dynatrace menu, go to Settings > Preferences > OneAgent features.
+   - Find and turn on OpenTelemetry Node.js Instrumentation agent support.
 2. W3C Trace Context:
-    - From the Dynatrace menu, go to Settings > Server-side service monitoring > Deep monitoring > Distributed tracing.
-    - Turn on Send W3C Trace Context HTTP headers.
+   - From the Dynatrace menu, go to Settings > Server-side service monitoring > Deep monitoring > Distributed tracing.
+   - Turn on Send W3C Trace Context HTTP headers.
 
 #### Leveraging Dynatrace OneAgent
 
@@ -259,7 +248,6 @@ That is, traces for background tasks started by `cds.spawn`, for example, would 
 
 If dependency `@opentelemetry/exporter-trace-otlp-proto` is present anyway, `@cap-js/telemetry` will export the traces via OpenTelemetry as well.
 
-
 ### `telemetry-to-cloud-logging`
 
 Exports traces and metrics to SAP Cloud Logging.
@@ -268,11 +256,13 @@ Hence, a SAP Cloud Logging instance is required and the app must be bound to tha
 Use via `cds.requires.telemetry.kind = 'to-cloud-logging'`.
 
 Required additional dependencies:
+
 - `@grpc/grpc-js`
 - `@opentelemetry/exporter-trace-otlp-grpc`
 - `@opentelemetry/exporter-metrics-otlp-grpc`
 
 In order to receive OpenTelemetry credentials in the binding to the SAP Cloud Logging instance, you need to include the following configuration while creating the SAP Cloud Logging instance (or by updating an existing instance):
+
 ```json
 {
   "ingest_otlp": {
@@ -283,10 +273,12 @@ In order to receive OpenTelemetry credentials in the binding to the SAP Cloud Lo
 
 If you are binding your app to SAP Cloud Logging via a [user-provided service instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html), make sure that it has the tag `Cloud Logging`.
 
-> Tip: To add the required tag to an existing user-provided service, you can use: 
+> Tip: To add the required tag to an existing user-provided service, you can use:
+>
 > ```
 > cf update-user-provided-service {service-name} -t "Cloud Logging"
 > ```
+>
 > For detailed information about binding resolution in CAP, consult [`cds.connect()` → Service Bindings](https://cap.cloud.sap/docs/node.js/cds-connect#service-bindings).
 
 ### `telemetry-to-jaeger`
@@ -296,9 +288,11 @@ Exports traces to Jaeger.
 Use via `cds.requires.telemetry.kind = 'to-jaeger'`.
 
 Required additional dependencies (As Jaeger does not support metrics, only a trace exporter is needed.):
+
 - `@opentelemetry/exporter-trace-otlp-proto`
 
 Provide custom credentials like so:
+
 ```jsonc
 {
   "cds": {
@@ -307,7 +301,8 @@ Provide custom credentials like so:
         "kind": "to-jaeger",
         "tracing": {
           "exporter": {
-            "config": { //> this object is passed into constructor as is
+            "config": {
+              //> this object is passed into constructor as is
               // add credentials here as decribed in
               // https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto
             }
@@ -320,10 +315,10 @@ Provide custom credentials like so:
 ```
 
 Run Jaeger locally via [docker](https://www.docker.com):
-- Run `docker run -d --name jaeger -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -e COLLECTOR_OTLP_ENABLED=true -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 4317:4317 -p 4318:4318 -p 14250:14250 -p 14268:14268 -p 14269:14269 -p 9411:9411 jaegertracing/all-in-one:latest`
-    - With this, no custom credentials are needed
-- Open `localhost:16686` to see the traces
 
+- Run `docker run -d --name jaeger -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -e COLLECTOR_OTLP_ENABLED=true -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 4317:4317 -p 4318:4318 -p 14250:14250 -p 14268:14268 -p 14269:14269 -p 9411:9411 jaegertracing/all-in-one:latest`
+  - With this, no custom credentials are needed
+- Open `localhost:16686` to see the traces
 
 ### `telemetry-to-otlp`
 
@@ -332,21 +327,20 @@ Exports traces and metrics to an OTLP/gRPC or OTLP/HTTP endpoint based on [envir
 Use via `cds.requires.telemetry.kind = 'to-otlp'`.
 
 Required additional dependencies (`* = grpc|proto|http`):
+
 - `@grpc/grpc-js` (in case of OTLP/gRPC)
 - `@opentelemetry/exporter-trace-otlp-*`
 - `@opentelemetry/exporter-metrics-otlp-*`
 
 Please note that `@cap-js/telemetry` does not validate the configuration via environment variables!
 
-
-
 ## Detailed Configuration Options
-
 
 ### Configuration Pass Through
 
 In general, you can influence the configuration of a used module via the respective `config` node in `cds.env.requires.telemetry`.
 For example, it is possible to specify the `temporalityPreference` setting of the respective metrics exporter like so:
+
 ```jsonc
 {
   "cds": {
@@ -354,7 +348,8 @@ For example, it is possible to specify the `temporalityPreference` setting of th
       "telemetry": {
         "metrics": {
           "exporter": {
-            "config": { //> this object is passed into constructor as is
+            "config": {
+              //> this object is passed into constructor as is
               "temporalityPreference": "DELTA"
             }
           }
@@ -365,7 +360,6 @@ For example, it is possible to specify the `temporalityPreference` setting of th
 }
 ```
 
-
 ### Resource Attributes
 
 Resource attributes describe the entity producing telemetry.
@@ -375,6 +369,7 @@ See [Resources](https://opentelemetry.io/docs/concepts/resources) and [Resource 
 You can configure additional attributes or also overwrite the derived attributes via `cds.requires.telemetry.resource.attributes = { <key>: <value>, ... }`
 
 Example:
+
 ```json
 {
   "service.version": "1.2.3",
@@ -382,12 +377,12 @@ Example:
 }
 ```
 
-
 ### Instrumentations
 
 Configure via `cds.requires.telemetry.instrumentations = { <name>: { module, class, config? } }`
 
 Default:
+
 ```json
 {
   "http": {
@@ -401,40 +396,39 @@ Default:
 }
 ```
 
-
 ### Sampler
 
 Configure via `cds.requires.telemetry.tracing.sampler = { kind, root?, ratio?, ignoreIncomingPaths? }`
 
 Default:
+
 ```json
 {
   "kind": "ParentBasedSampler",
   "root": "AlwaysOnSampler",
-  "ignoreIncomingPaths": [
-    "/health"
-  ]
+  "ignoreIncomingPaths": ["/health"]
 }
 ```
-
 
 ### Propagators
 
 Configure via `cds.requires.telemetry.tracing.propagators = [<name> | { module, class, config? }]`
 
 Default:
+
 ```json
 ["W3CTraceContextPropagator", "W3CBaggagePropagator"]
 ```
 
-
 ### Exporters
 
 Configure via:
+
 - `cds.requires.telemetry.tracing.exporter = { module, class, config? }`
 - `cds.requires.telemetry.metrics.exporter = { module, class, config? }`
 
 Default:
+
 ```json
 {
   {
@@ -493,40 +487,39 @@ Default:
 #### Some Alternative Exporters
 
 1. For JSON output to the console, use:
-    ```json
-    {
-      "tracing": {
-        "exporter": {
-          "module": "@opentelemetry/sdk-trace-base",
-          "class": "ConsoleSpanExporter"
-        }
-      },
-      "metrics": {
-        "exporter": {
-          "module": "@opentelemetry/sdk-metrics",
-          "class": "ConsoleMetricExporter"
-        }
-      }
-    }
-    ```
+   ```json
+   {
+     "tracing": {
+       "exporter": {
+         "module": "@opentelemetry/sdk-trace-base",
+         "class": "ConsoleSpanExporter"
+       }
+     },
+     "metrics": {
+       "exporter": {
+         "module": "@opentelemetry/sdk-metrics",
+         "class": "ConsoleMetricExporter"
+       }
+     }
+   }
+   ```
 1. For HTTP, use:
-    ```json
-    {
-      "tracing": {
-        "exporter": {
-          "module": "@opentelemetry/exporter-trace-otlp-http",
-          "class": "OTLPTraceExporter"
-        }
-      },
-      "metrics": {
-        "exporter": {
-          "module": "@opentelemetry/exporter-metrics-otlp-http",
-          "class": "OTLPMetricExporter"
-        }
-      }
-    }
-    ```
-
+   ```json
+   {
+     "tracing": {
+       "exporter": {
+         "module": "@opentelemetry/exporter-trace-otlp-http",
+         "class": "OTLPTraceExporter"
+       }
+     },
+     "metrics": {
+       "exporter": {
+         "module": "@opentelemetry/exporter-metrics-otlp-http",
+         "class": "OTLPMetricExporter"
+       }
+     }
+   }
+   ```
 
 ### High Resolution Timestamps (beta)
 
@@ -534,7 +527,6 @@ By default, the start time of a span is taken from `Date.now()` and, hence, has 
 Via `cds.requires.telemetry.tracing.hrtime = true`, you can instruct the plugin to specify the start and end times of spans, which it does with nanosecond resolution.
 This may result in minor drifts, especially for spans created by other instrumentations such as `@opentelemetry/instrumentation-http`.
 Hence, the `hrtime` mode is on by default in development but not in production.
-
 
 ### Environment Variables
 
@@ -549,25 +541,18 @@ For the complete list of environment variables supported by OpenTelemetry, see [
 
 Please note that `process.env.VCAP_APPLICATION` and `process.env.CF_INSTANCE_GUID`, if present, are used to determine some [Attributes](https://opentelemetry.io/docs/specs/otel/common/#attribute).
 
-
-
 ## Custom Spans (beta)
 
 Custom spans can be added to the trace hierarchy via [`tracer.startActiveSpan()`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.Tracer.html#startactivespan).
 For this, you need to create your own tracer via [TraceAPI.getTracer()](https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html#gettracer).
 
-
-
 ## Support, Feedback, Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-js/telemetry/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
-
-
 ## Code of Conduct
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/cap-js/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
-
 
 ## Licensing
 

--- a/lib/exporter/ConsoleMetricExporter.js
+++ b/lib/exporter/ConsoleMetricExporter.js
@@ -119,7 +119,9 @@ class ConsoleMetricExporter extends StandardConsoleMetricExporter {
         // export other metrics
         for (const tenant of Object.keys(other)) {
           for (const [k, v] of Object.entries(other[tenant])) {
-            LOG.info(`${k}${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}: ${inspect(v.length === 1 ? v[0] : v)}`)
+            LOG.info(
+              `${k}${tenant !== 'undefined' ? ` of tenant "${tenant}"` : ''}: ${inspect(v.length === 1 ? v[0] : v)}`
+            )
           }
         }
       }

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -40,7 +40,10 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
+    if (!credentials)
+      throw new Error(
+        'No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".'
+      )
     augmentCLCreds(credentials)
     config.url ??= credentials.url
     config.credentials ??= credentials.credentials

--- a/lib/metrics/index.js
+++ b/lib/metrics/index.js
@@ -50,7 +50,8 @@ function _getExporter() {
   // Augment configuration depending on 'kind' of telemetry
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
-    if (!credentials) throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
+    if (!credentials)
+      throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
     config.url ??= `${credentials.apiurl}/v2/otlp/v1/metrics`
     config.headers ??= {}
 
@@ -67,7 +68,10 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
+    if (!credentials)
+      throw new Error(
+        'No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".'
+      )
     augmentCLCreds(credentials)
 
     config.url ??= credentials.url

--- a/lib/tracing/cloud_sdk.js
+++ b/lib/tracing/cloud_sdk.js
@@ -36,7 +36,11 @@ module.exports = () => {
       })
     }
   })
-  Object.defineProperty(cloudSDK, 'executeHttpRequest', { value: _executeHttpRequest, writable: true, configurable: true })
+  Object.defineProperty(cloudSDK, 'executeHttpRequest', {
+    value: _executeHttpRequest,
+    writable: true,
+    configurable: true
+  })
   const _executeHttpRequestWithOrigin = wrap(_executeWithOrigin, {
     wrapper: function executeHttpRequestWithOrigin(destination, requestConfig) {
       return trace(_cloudSdkSpanName(destination, requestConfig), _executeWithOrigin, this, arguments, {
@@ -45,5 +49,9 @@ module.exports = () => {
       })
     }
   })
-  Object.defineProperty(cloudSDK, 'executeHttpRequestWithOrigin', { value: _executeHttpRequestWithOrigin, writable: true, configurable: true })
+  Object.defineProperty(cloudSDK, 'executeHttpRequestWithOrigin', {
+    value: _executeHttpRequestWithOrigin,
+    writable: true,
+    configurable: true
+  })
 }

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -106,7 +106,8 @@ function _getExporter() {
 
   if (kind.match(/to-dynatrace$/)) {
     if (!credentials) credentials = getCredsForDTAsUPS()
-    if (!credentials) throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
+    if (!credentials)
+      throw new Error('No Dynatrace credentials found. Make sure the bound service instance uses the tag "dynatrace".')
     config.url ??= `${credentials.apiurl}/v2/otlp/v1/traces`
     config.headers ??= {}
     // credentials.rest_apitoken?.token is deprecated and only supported for compatibility reasons
@@ -119,7 +120,10 @@ function _getExporter() {
 
   if (kind.match(/to-cloud-logging$/)) {
     if (!credentials) credentials = getCredsForCLSAsUPS()
-    if (!credentials) throw new Error('No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".')
+    if (!credentials)
+      throw new Error(
+        'No SAP Cloud Logging credentials found. Make sure the bound service instance uses the tag "Cloud Logging".'
+      )
     augmentCLCreds(credentials)
     config.url ??= credentials.url
     config.credentials ??= credentials.credentials

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "@sap/cds-mtxs": "^4",
         "axios": "^1.6.7",
         "eslint": "^10",
-        "jest": "^30.4.2"
+        "jest": "^30.4.2",
+        "prettier": "3.9.6"
       },
       "peerDependencies": {
         "@sap/cds": "^10 || ^9"
@@ -6975,6 +6976,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -111,8 +111,12 @@
         },
         "telemetry-to-dynatrace": {
           "vcap": [
-            { "label": "dynatrace" },
-            { "tag": "dynatrace" }
+            {
+              "label": "dynatrace"
+            },
+            {
+              "tag": "dynatrace"
+            }
           ],
           "tracing": {
             "exporter": {
@@ -130,8 +134,12 @@
         },
         "telemetry-to-cloud-logging": {
           "vcap": [
-            { "label": "cloud-logging" },
-            { "tag": "Cloud Logging" }
+            {
+              "label": "cloud-logging"
+            },
+            {
+              "tag": "Cloud Logging"
+            }
           ],
           "tracing": {
             "exporter": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   ],
   "scripts": {
     "lint": "npx eslint . --max-warnings=0",
-    "test": "npx jest --silent"
+    "test": "npx jest --silent",
+    "format": "npx prettier --write .",
+    "format:check": "npx prettier --check ."
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9",
@@ -47,7 +49,8 @@
     "@sap/cds-mtxs": "^4",
     "axios": "^1.6.7",
     "eslint": "^10",
-    "jest": "^30.4.2"
+    "jest": "^30.4.2",
+    "prettier": "3.9.6"
   },
   "cds": {
     "requires": {

--- a/test/bookshop/srv/admin-service.js
+++ b/test/bookshop/srv/admin-service.js
@@ -43,11 +43,7 @@ module.exports = class AdminService extends cds.ApplicationService {
     this.on('test_outboxed_send_batch', async () => {
       const externalOne = await cds.connect.to('ExternalServiceOne')
       const queued = cds.queued(externalOne)
-      await Promise.all([
-        queued.send('call', {}),
-        queued.send('call', {}),
-        queued.send('call', {})
-      ])
+      await Promise.all([queued.send('call', {}), queued.send('call', {}), queued.send('call', {})])
     })
 
     // test_scheduled: schedules a one-shot task to fire after a short delay.

--- a/test/console-span-exporter.test.js
+++ b/test/console-span-exporter.test.js
@@ -80,9 +80,30 @@ describe('ConsoleSpanExporter', () => {
       //     childB (5 → 9 ms)
       const TRACE = 'a'.repeat(32)
       const root = span({ name: 'root', traceId: TRACE, spanId: 'r0', startMs: 0, durationMs: 10 })
-      const childA = span({ name: 'childA', traceId: TRACE, spanId: 'cA', parentSpanId: 'r0', startMs: 1, durationMs: 3 })
-      const grand = span({ name: 'grandchild', traceId: TRACE, spanId: 'g0', parentSpanId: 'cA', startMs: 2, durationMs: 1 })
-      const childB = span({ name: 'childB', traceId: TRACE, spanId: 'cB', parentSpanId: 'r0', startMs: 5, durationMs: 4 })
+      const childA = span({
+        name: 'childA',
+        traceId: TRACE,
+        spanId: 'cA',
+        parentSpanId: 'r0',
+        startMs: 1,
+        durationMs: 3
+      })
+      const grand = span({
+        name: 'grandchild',
+        traceId: TRACE,
+        spanId: 'g0',
+        parentSpanId: 'cA',
+        startMs: 2,
+        durationMs: 1
+      })
+      const childB = span({
+        name: 'childB',
+        traceId: TRACE,
+        spanId: 'cB',
+        parentSpanId: 'r0',
+        startMs: 5,
+        durationMs: 4
+      })
 
       // Order matters: children must arrive BEFORE the root for the exporter's
       // temporaryStorage flush logic to merge them under the same primer.
@@ -111,7 +132,14 @@ describe('ConsoleSpanExporter', () => {
       // Root starts at 100 ms wallclock; child at 105 ms. Child should display as 5.00 → ...
       const TRACE = 'b'.repeat(32)
       const root = span({ name: 'root', traceId: TRACE, spanId: 'r0', startMs: 100, durationMs: 20 })
-      const child = span({ name: 'child', traceId: TRACE, spanId: 'c0', parentSpanId: 'r0', startMs: 105, durationMs: 10 })
+      const child = span({
+        name: 'child',
+        traceId: TRACE,
+        spanId: 'c0',
+        parentSpanId: 'r0',
+        startMs: 105,
+        durationMs: 10
+      })
 
       const [primer] = exportAndCapture([child, root])
 
@@ -123,8 +151,22 @@ describe('ConsoleSpanExporter', () => {
       const TRACE = 'c'.repeat(32)
       const root = span({ name: 'root', traceId: TRACE, spanId: 'r0', startMs: 0, durationMs: 50 })
       const late = span({ name: 'late', traceId: TRACE, spanId: 's3', parentSpanId: 'r0', startMs: 10, durationMs: 1 })
-      const earlyLong = span({ name: 'earlyLong', traceId: TRACE, spanId: 's1', parentSpanId: 'r0', startMs: 0, durationMs: 30 })
-      const earlyShort = span({ name: 'earlyShort', traceId: TRACE, spanId: 's2', parentSpanId: 'r0', startMs: 0, durationMs: 5 })
+      const earlyLong = span({
+        name: 'earlyLong',
+        traceId: TRACE,
+        spanId: 's1',
+        parentSpanId: 'r0',
+        startMs: 0,
+        durationMs: 30
+      })
+      const earlyShort = span({
+        name: 'earlyShort',
+        traceId: TRACE,
+        spanId: 's2',
+        parentSpanId: 'r0',
+        startMs: 0,
+        durationMs: 5
+      })
 
       const [primer] = exportAndCapture([late, earlyShort, earlyLong, root])
 
@@ -154,7 +196,14 @@ describe('ConsoleSpanExporter', () => {
       const TRACE = 'f'.repeat(32)
       const root = span({ name: 'root', traceId: TRACE, spanId: 'r0', startMs: 0, durationMs: 10 })
       // The skip regex is /^[A-Z]+ \/\${0,1}\w+$/ — single path segment, no slashes after the first.
-      const noisy = span({ name: 'GET /catalog', traceId: TRACE, spanId: 'h0', parentSpanId: 'r0', startMs: 1, durationMs: 5 })
+      const noisy = span({
+        name: 'GET /catalog',
+        traceId: TRACE,
+        spanId: 'h0',
+        parentSpanId: 'r0',
+        startMs: 1,
+        durationMs: 5
+      })
 
       const [primer] = exportAndCapture([noisy, root])
 
@@ -215,7 +264,14 @@ describe('ConsoleSpanExporter', () => {
     it('does not throw when a child arrives without its parent (orphan trace)', () => {
       // No root provided for this trace — the exporter should buffer the child and not flush.
       const TRACE = '5'.repeat(32)
-      const orphan = span({ name: 'orphan', traceId: TRACE, spanId: 'o0', parentSpanId: 'r-missing', startMs: 0, durationMs: 1 })
+      const orphan = span({
+        name: 'orphan',
+        traceId: TRACE,
+        spanId: 'o0',
+        parentSpanId: 'r-missing',
+        startMs: 0,
+        durationMs: 1
+      })
 
       expect(() => exportAndCapture([orphan])).not.to.throw()
       expect(infoCalls.length).to.equal(0)

--- a/test/tracing-attributes.test.js
+++ b/test/tracing-attributes.test.js
@@ -78,14 +78,18 @@ describe('tracing attributes', () => {
 
     test('SELECT', async () => {
       await SELECT.from('sap.capire.bookshop.Books').where('title !=', 'DUMMY')
-      const rowCounts = dbSpans().map(s => s.attributes['db.client.response.returned_rows']).filter(v => v != null)
+      const rowCounts = dbSpans()
+        .map(s => s.attributes['db.client.response.returned_rows'])
+        .filter(v => v != null)
       expect(rowCounts).to.include(5)
       _match_db_spans('SELECT')
     })
 
     test('INSERT', async () => {
       await INSERT.into('sap.capire.bookshop.Books').entries([{ ID: 1 }, { ID: 2 }])
-      const rowCounts = dbSpans().map(s => s.attributes['db.client.response.returned_rows']).filter(v => v != null)
+      const rowCounts = dbSpans()
+        .map(s => s.attributes['db.client.response.returned_rows'])
+        .filter(v => v != null)
       expect(rowCounts).to.include(2)
       // TODO
       // _match_db_spans('INSERT')
@@ -93,7 +97,9 @@ describe('tracing attributes', () => {
 
     test('UPDATE', async () => {
       await UPDATE('sap.capire.bookshop.Books').set({ stock: 42 }).where('ID > 250')
-      const rowCounts = dbSpans().map(s => s.attributes['db.client.response.returned_rows']).filter(v => v != null)
+      const rowCounts = dbSpans()
+        .map(s => s.attributes['db.client.response.returned_rows'])
+        .filter(v => v != null)
       expect(rowCounts).to.include(3)
       // TODO
       // _match_db_spans('UPDATE')
@@ -101,7 +107,9 @@ describe('tracing attributes', () => {
 
     test('DELETE', async () => {
       await DELETE.from('sap.capire.bookshop.Books')
-      const rowCounts = dbSpans().map(s => s.attributes['db.client.response.returned_rows']).filter(v => v != null)
+      const rowCounts = dbSpans()
+        .map(s => s.attributes['db.client.response.returned_rows'])
+        .filter(v => v != null)
       expect(rowCounts).to.include(0) // texts
       expect(rowCounts).to.include(5)
       // TODO

--- a/test/tracing-outboxed-batch.test.js
+++ b/test/tracing-outboxed-batch.test.js
@@ -36,16 +36,18 @@ describe('tracing for outboxed batch (chunk-size fan-out)', () => {
     expect(upserts.length, 'expected three producer outbox UPSERTs').to.be.gte(3)
 
     // Look for a queue worker root containing multiple dispatch tx spans.
-    const workerTrace = groupedByTrace().find(g =>
-      g.root.name === 'cds.spawn - run task' &&
-      g.all.filter(s => s.name === 'ExternalServiceOne - tx').length >= 2
+    const workerTrace = groupedByTrace().find(
+      g => g.root.name === 'cds.spawn - run task' && g.all.filter(s => s.name === 'ExternalServiceOne - tx').length >= 2
     )
     expect(workerTrace, 'expected a worker trace with multiple ExternalServiceOne - tx children').to.exist
 
     // The worker root must have exactly one lock tx (db - tx with READ + UPDATE)…
-    const lockTxs = workerTrace.all.filter(s =>
-      s.name === 'db - tx' &&
-      workerTrace.all.some(c => c.parentSpanContext?.spanId === s.spanContext().spanId && c.name === 'db - READ cds.outbox.Messages')
+    const lockTxs = workerTrace.all.filter(
+      s =>
+        s.name === 'db - tx' &&
+        workerTrace.all.some(
+          c => c.parentSpanContext?.spanId === s.spanContext().spanId && c.name === 'db - READ cds.outbox.Messages'
+        )
     )
     expect(lockTxs, 'expected one lock tx (db - tx with READ + UPDATE)').to.have.lengthOf(1)
 
@@ -54,8 +56,14 @@ describe('tracing for outboxed batch (chunk-size fan-out)', () => {
     expect(dispatchTxs.length, 'expected multiple dispatch txs (chunk-size fan-out)').to.be.gte(2)
     for (const tx of dispatchTxs) {
       const kids = workerTrace.all.filter(k => k.parentSpanContext?.spanId === tx.spanContext().spanId)
-      expect(kids.some(k => k.name.match(/ExternalServiceOne - handle/)), 'dispatch tx should contain handle call').to.be.true
-      expect(kids.some(k => k.name === 'db - DELETE cds.outbox.Messages'), 'dispatch tx should contain DELETE').to.be.true
+      expect(
+        kids.some(k => k.name.match(/ExternalServiceOne - handle/)),
+        'dispatch tx should contain handle call'
+      ).to.be.true
+      expect(
+        kids.some(k => k.name === 'db - DELETE cds.outbox.Messages'),
+        'dispatch tx should contain DELETE'
+      ).to.be.true
     }
 
     // The dispatch txs should overlap in time (parallel), not be strictly sequential.

--- a/test/tracing-remote-native.test.js
+++ b/test/tracing-remote-native.test.js
@@ -44,9 +44,7 @@ describe('tracing remote via native fetch', () => {
     // no mock handler - let it make the actual HTTP call via native fetch
     await remote.send({ method: 'GET', path: '/test' })
 
-    const undiciSpan = getSpans().find(
-      s => s.instrumentationScope?.name === '@opentelemetry/instrumentation-undici'
-    )
+    const undiciSpan = getSpans().find(s => s.instrumentationScope?.name === '@opentelemetry/instrumentation-undici')
     expect(undiciSpan, 'no span from @opentelemetry/instrumentation-undici').to.exist
     expect(undiciSpan.attributes['http.request.method']).to.equal('GET')
     expect(undiciSpan.attributes['http.response.status_code']).to.equal(200)


### PR DESCRIPTION
Supersedes the #438 oxfmt spike with a proper formatter adoption.

## Formatter: prettier (pinned `3.9.6`)

Chosen over oxfmt: ubiquitous and battle-tested, the repo already carries `// prettier-ignore` comments in several files (so it anticipates prettier), and there's no org standardization on oxfmt. No eslint conflict — `@sap/cds/eslint.config.mjs` is `recommended` + `no-unused-vars`/`no-console` only (correctness, no stylistic rules), so eslint and prettier don't fight and no `eslint-config-prettier` is needed.

## Config (`.prettierrc.json`) — matches existing house style

`singleQuote`, `semi: false`, `printWidth: 120`, `tabWidth: 2`, `trailingComma: none`, `arrowParens: avoid`. `.prettierignore` covers `node_modules`, `package-lock.json`, `CHANGELOG.md`, and `jest.config.js` (see coordination note).

## Commits (reviewable split)

1. `chore: add prettier formatter tooling` — config + `.prettierignore` + `format`/`format:check` scripts + devDep + lockfile (no reformat)
2. `chore: apply prettier formatting` — pure reformat (line-wrapping only, no behavior change; verified via `git diff -w` showing only reflow)
3. `ci: run format:check in the lint job` — one line in ci.yml

No git hook added — the CI `format:check` step + scripts enforce without forcing husky/lint-staged on contributors.

## Verified
- `npm run format:check` ✅ · `npm run lint` (--max-warnings=0) ✅ · `npm run test` → 53 pass / 14 skip
- lockfile resolved against public npm (0 internal-registry URLs)

## Coordination
Parallel PR (jest→vitest) deletes `jest.config.js` and changes the test script + lockfile. This PR excludes `jest.config.js` from formatting and its `package.json` change is additive (scripts + devDep). Lockfile will likely conflict — whichever merges second rebases.