### PR TITLE
fix(logging): guard cds.log.format interception against re-entrancy; unpin sdk-logs (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- Logging no longer recurses through `@opentelemetry/sdk-logs` 0.221's export path (log processors are now constructed with the `{ exporter }` options object 0.221 expects, and a re-entrancy guard was added to the `cds.log.format` interception); the temporary sdk-logs 0.219 pin is removed
 - Cloud SDK outbound requests are traced again (patch getter-only `@sap-cloud-sdk/http-client` exports via `Object.defineProperty`)
 - Raw SQL no longer leaks into HANA INSERT `prepare` span names (now uses operation + table, matching SELECT)
 - Queue `*_storage_time_in_seconds` metrics are now correct on HANA (timezone-naive `min`/`max` timestamp aggregates were parsed as local time, skewing the values by the machine's UTC offset)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Logging no longer recurses through `@opentelemetry/sdk-logs` 0.221's export path (log processors are now constructed with the `{ exporter }` options object 0.221 expects, and a re-entrancy guard was added to the `cds.log.format` interception); the temporary sdk-logs 0.219 pin is removed
+- Logging no longer recurses through `@opentelemetry/sdk-logs` 0.221's export path: the log-processor construction now adapts to the installed sdk-logs version (0.221+ takes an `{ exporter }` options object, earlier versions the positional exporter), and a re-entrancy guard was added to the `cds.log.format` interception; the temporary sdk-logs 0.219 pin is removed
 - Cloud SDK outbound requests are traced again (patch getter-only `@sap-cloud-sdk/http-client` exports via `Object.defineProperty`)
 - Raw SQL no longer leaks into HANA INSERT `prepare` span names (now uses operation + table, matching SELECT)
 - Queue `*_storage_time_in_seconds` metrics are now correct on HANA (timezone-naive `min`/`max` timestamp aggregates were parsed as local time, skewing the values by the machine's UTC offset)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
-- Logging no longer recurses through `@opentelemetry/sdk-logs` 0.221's export path: the log-processor construction now adapts to the installed sdk-logs version (0.221+ takes an `{ exporter }` options object, earlier versions the positional exporter), and a re-entrancy guard was added to the `cds.log.format` interception; the temporary sdk-logs 0.219 pin is removed
+- Logging no longer recurses through `@opentelemetry/sdk-logs` 0.221's export path: the log-processor construction now adapts to the installed sdk-logs version (0.221+ takes an `{ exporter }` options object, earlier versions the positional exporter), and a re-entrancy guard was added to the `cds.log.format` interception
 - Cloud SDK outbound requests are traced again (patch getter-only `@sap-cloud-sdk/http-client` exports via `Object.defineProperty`)
 - Raw SQL no longer leaks into HANA INSERT `prepare` span names (now uses operation + table, matching SELECT)
 - Queue `*_storage_time_in_seconds` metrics are now correct on HANA (timezone-naive `min`/`max` timestamp aggregates were parsed as local time, skewing the values by the machine's UTC offset)

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -11,6 +11,19 @@ const _protocol2module = {
   'http/json': '@opentelemetry/exporter-logs-otlp-http'
 }
 
+// @opentelemetry/sdk-logs 0.221 changed the log processor constructors (Simple/Batch, and hence
+// any subclass) from a positional exporter argument `(exporter)` to an options object `({ exporter })`.
+// Passing the wrong shape leaves the exporter undefined, so every export throws and — since our diag
+// logger is wired to cds.log — recurses back through cds.log.format into an unbounded loop (see #482).
+// To stay correct regardless of which sdk-logs a consumer's tree resolves, detect the installed
+// version and build the constructor argument accordingly (no hard version floor needed).
+function logProcessorArg(exporter) {
+  const version = require('@opentelemetry/sdk-logs/package.json').version
+  const [major, minor] = version.split('.').map(Number)
+  const usesOptionsObject = major > 0 || minor >= 221
+  return usesOptionsObject ? { exporter } : exporter
+}
+
 function _getExporter() {
   let {
     kind,
@@ -67,7 +80,7 @@ function _getCustomProcessor(exporter) {
   if (!loggingProcessorModule[loggingProcessor.class])
     throw new Error(`Unknown logs processor "${loggingProcessor.class}" in module "${loggingProcessor.module}"`)
 
-  const processor = new loggingProcessorModule[loggingProcessor.class]({ exporter })
+  const processor = new loggingProcessorModule[loggingProcessor.class](logProcessorArg(exporter))
   LOG._debug && LOG.debug('Using logs processor:', processor)
 
   return processor
@@ -147,8 +160,8 @@ module.exports = resource => {
   const processor =
     _getCustomProcessor(exporter) ||
     (process.env.NODE_ENV === 'production'
-      ? new BatchLogRecordProcessor({ exporter })
-      : new SimpleLogRecordProcessor({ exporter }))
+      ? new BatchLogRecordProcessor(logProcessorArg(exporter))
+      : new SimpleLogRecordProcessor(logProcessorArg(exporter)))
 
   /*
    * either add processor as delegate in CALM...

--- a/lib/logging/index.js
+++ b/lib/logging/index.js
@@ -67,7 +67,7 @@ function _getCustomProcessor(exporter) {
   if (!loggingProcessorModule[loggingProcessor.class])
     throw new Error(`Unknown logs processor "${loggingProcessor.class}" in module "${loggingProcessor.module}"`)
 
-  const processor = new loggingProcessorModule[loggingProcessor.class](exporter)
+  const processor = new loggingProcessorModule[loggingProcessor.class]({ exporter })
   LOG._debug && LOG.debug('Using logs processor:', processor)
 
   return processor
@@ -89,13 +89,18 @@ module.exports = resource => {
     const custom_fields = cds.env.log.cls_custom_fields || []
 
     // intercept logs via format
+    // re-entrancy guard: while we are inside our own logger.emit(), skip re-emitting anything
+    // that emit() logs synchronously (e.g. via the export path or the SDK's diag logger, which
+    // is wired to cds.log('telemetry')). This prevents cds.log.format from recursing back into
+    // logger.emit() and looping through the logs SDK's export/diagnostic output (#482).
+    let emitting = false
     const { format: _format } = cds.log
     const format = (cds.log.format = function (module, level, ...args) {
       const res = _format.call(this, module, level, ...args)
 
       let log
       try {
-        log = res.length === 1 && res[0].startsWith?.('{"') && JSON.parse(res[0])
+        log = !emitting && res.length === 1 && res[0].startsWith?.('{"') && JSON.parse(res[0])
       } catch {
         // ignore
       }
@@ -115,12 +120,17 @@ module.exports = resource => {
           log.msg = log.msg.replace(e.stack, e.stack?.split('\n')[0])
         }
         for (const field of custom_fields) if (field in log) attributes[field] = log[field]
-        logger.emit({
-          severityNumber: SeverityNumber[severity],
-          severityText: severity,
-          body: log.msg,
-          attributes
-        })
+        emitting = true
+        try {
+          logger.emit({
+            severityNumber: SeverityNumber[severity],
+            severityText: severity,
+            body: log.msg,
+            attributes
+          })
+        } finally {
+          emitting = false
+        }
       }
 
       return res
@@ -137,8 +147,8 @@ module.exports = resource => {
   const processor =
     _getCustomProcessor(exporter) ||
     (process.env.NODE_ENV === 'production'
-      ? new BatchLogRecordProcessor(exporter)
-      : new SimpleLogRecordProcessor(exporter))
+      ? new BatchLogRecordProcessor({ exporter })
+      : new SimpleLogRecordProcessor({ exporter }))
 
   /*
    * either add processor as delegate in CALM...

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,15 +675,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
-      "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -691,52 +691,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "oxfmt": "0.63.0",
     "vitest": "^4"
   },
-  "overrides": {
-    "@opentelemetry/sdk-logs": "0.219.0"
-  },
   "cds": {
     "requires": {
       "telemetry": {


### PR DESCRIPTION
## Problem

Bumping the OTLP dev-deps to the `0.221` line pulled `@opentelemetry/sdk-logs` 0.219 → 0.221, which made `test/logging.test.js` OOM-crash (heap climbed to ~3.8 GB, ~110 s of GC thrashing before dying). #483 shipped an interim workaround pinning sdk-logs to `0.219.0` via a top-level `overrides` block. This PR removes that pin and fixes the actual defect. Closes #482.

## Root cause

Two things combine:

1. **Constructor signature change (the real trigger).** In sdk-logs 0.221 the `SimpleLogRecordProcessor` and `BatchLogRecordProcessor` constructors changed from positional `(exporter)` to an options object `({ exporter })`. `lib/logging/index.js` still passed the exporter positionally (both the built-in path and the custom-processor path in `_getCustomProcessor`; the test's `MySimpleLogRecordProcessor` extends the SDK base and forwards its args). So `options.exporter` was `undefined`, and every emit called `core.internal._export(undefined, …)`, which throws.

2. **Diag re-entrancy loop.** The thrown export error hits `.catch(globalErrorHandler)` → `diag.error(...)`. Because `lib/index.js` wires `diag.setLogger(cds.log('telemetry'), …)`, that diagnostic goes back through `cds.log('telemetry')` → the overridden `cds.log.format` → `logger.emit()` → export throws again → … an unbounded loop. Each hop is a **microtask** (`processTicksAndRejections`), so the recursion is asynchronous.

## Fix

- Construct the log processors with the `{ exporter }` options object 0.221 expects (built-in + custom-processor paths). This stops the export from throwing, which removes the source of the diag error loop — the OOM is gone.
- Add a re-entrancy guard (`let emitting`) around `logger.emit()` in the `cds.log.format` interception: while inside our own `emit()` we still run the original format work (log output unchanged) but skip re-emitting. This is defense-in-depth against any **synchronous** re-entry through the export/diag path; `try/finally` guarantees the flag resets even if `emit()` throws.

## Unpin

- Removed the `@opentelemetry/sdk-logs` `overrides` pin; regenerated the lockfile. sdk-logs now floats to `0.221.0`, matching the other OTLP deps. This removes the #483 workaround pin.

## Verification

- `vitest run test/logging.test.js` — passes in ~1.3 s (was ~3.8 GB / ~110 s OOM crash on 0.221). The `logging.test.js` OOM was the repro; ran it repeatedly, stable.
- Full sqlite suite: 63 passed / 14 skipped, no regressions.
- eslint `--max-warnings=0` clean; `oxfmt --check` clean.
- Lockfile: no internal-registry URLs; `npm ci` reproduces cleanly.