### PR TITLE
test: convert remote/span-name tracing tests to in-memory span exporter; drop tracing-attributes profile (#478)

### DIFF
--- a/test/bookshop/.cdsrc.json
+++ b/test/bookshop/.cdsrc.json
@@ -75,17 +75,6 @@
       }
     }
   },
-  "[tracing-attributes]": {
-    "requires": {
-      "telemetry": {
-        "tracing": {
-          "exporter": {
-            "module": "@opentelemetry/sdk-trace-node"
-          }
-        }
-      }
-    }
-  },
   "[tracing-in-memory]": {
     "requires": {
       "telemetry": {

--- a/test/tracing-remote-cloudsdk.test.js
+++ b/test/tracing-remote-cloudsdk.test.js
@@ -1,6 +1,11 @@
 const cds = require('@sap/cds')
-const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-attributes')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
 const http = require('http')
+
+// The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures
+// MyInMemorySpanExporter as the trace exporter. We read the captured ReadableSpan
+// objects directly out of its shared buffer — no console spy.
+const { captured, reset } = require('./bookshop/lib/MyInMemorySpanExporter')
 
 // Cloud SDK path: with @sap-cloud-sdk/http-client installed (as in the bookshop) and
 // cds.env.remote.native_fetch NOT set, CAP routes outbound remote calls through
@@ -8,10 +13,9 @@ const http = require('http')
 // export so the outbound call produces a @cap-js/telemetry CLIENT span carrying
 // the sap.btp.destination attribute.
 describe('tracing remote via cloud sdk', () => {
-  const log = vi.spyOn(console, 'dir')
-  beforeEach(log.mockClear)
+  beforeEach(reset)
 
-  const getSpans = () => log.mock.calls.map(c => c[0]).filter(Boolean)
+  const getSpans = () => captured
   const getCapSpans = () => getSpans().filter(s => s.instrumentationScope?.name === '@cap-js/telemetry')
 
   let server, port

--- a/test/tracing-remote-native.test.js
+++ b/test/tracing-remote-native.test.js
@@ -3,8 +3,13 @@
 process.env.cds_remote_native__fetch = 'true'
 
 const cds = require('@sap/cds')
-const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-attributes')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
 const http = require('http')
+
+// The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures
+// MyInMemorySpanExporter as the trace exporter. We read the captured ReadableSpan
+// objects directly out of its shared buffer — no console spy.
+const { captured, reset } = require('./bookshop/lib/MyInMemorySpanExporter')
 
 // Native fetch path: when cds.env.remote.native_fetch === true (or no cloud sdk is
 // installed), CAP routes outbound remote calls through native fetch, which is
@@ -12,10 +17,9 @@ const http = require('http')
 // comes from that instrumentation scope (NOT @opentelemetry/instrumentation-http, and
 // NOT our cloud_sdk wrapper) and carries the standard http.* / url.* / server.* attributes.
 describe('tracing remote via native fetch', () => {
-  const log = vi.spyOn(console, 'dir')
-  beforeEach(log.mockClear)
+  beforeEach(reset)
 
-  const getSpans = () => log.mock.calls.map(c => c[0]).filter(Boolean)
+  const getSpans = () => captured
 
   let server, port
 

--- a/test/tracing-span-names.test.js
+++ b/test/tracing-span-names.test.js
@@ -5,14 +5,14 @@ const http = require('http')
 // The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures
 // MyInMemorySpanExporter as the trace exporter. We read the captured ReadableSpan
 // objects directly out of its shared buffer — no console spy.
-const { captured } = require('./bookshop/lib/MyInMemorySpanExporter')
+const { captured, reset } = require('./bookshop/lib/MyInMemorySpanExporter')
 
 describe('span names', () => {
   beforeEach(async () => {
     // data.reset is itself heavily traced (it runs DELETEs + INSERTs for the seed data) —
     // run it first, THEN clear the buffer so the test only sees its own spans.
     await data.reset()
-    captured.length = 0
+    reset()
   })
 
   const getSpans = () => captured

--- a/test/tracing-span-names.test.js
+++ b/test/tracing-span-names.test.js
@@ -1,14 +1,21 @@
 const cds = require('@sap/cds')
-const { expect, data } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-attributes')
+const { expect, data } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
 const http = require('http')
 
+// The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures
+// MyInMemorySpanExporter as the trace exporter. We read the captured ReadableSpan
+// objects directly out of its shared buffer — no console spy.
+const { captured } = require('./bookshop/lib/MyInMemorySpanExporter')
+
 describe('span names', () => {
-  beforeEach(data.reset)
+  beforeEach(async () => {
+    // data.reset is itself heavily traced (it runs DELETEs + INSERTs for the seed data) —
+    // run it first, THEN clear the buffer so the test only sees its own spans.
+    await data.reset()
+    captured.length = 0
+  })
 
-  const log = vi.spyOn(console, 'dir')
-  beforeEach(log.mockClear)
-
-  const getSpans = () => log.mock.calls.map(c => c[0]).filter(Boolean)
+  const getSpans = () => captured
 
   // Spans from our tracer only (excludes HTTP instrumentation spans)
   const getCapSpans = () => getSpans().filter(s => s.instrumentationScope?.name === '@cap-js/telemetry')


### PR DESCRIPTION
## What

Group 1 of #478. Converts the three tracing tests that still spied on `console.dir` to read structured `ReadableSpan` objects directly from the in-memory span exporter:

- `test/tracing-remote-cloudsdk.test.js`
- `test/tracing-remote-native.test.js`
- `test/tracing-span-names.test.js`

Each now uses `--profile tracing-in-memory` (which wires `MyInMemorySpanExporter` via `.cdsrc.json`) and reads over `captured` (the module-level array of `ReadableSpan`s) instead of the `console.dir` spy. `beforeEach(reset)` clears the buffer per test. All existing assertions are preserved verbatim — `instrumentationScope.name` filters (`@cap-js/telemetry`, `@opentelemetry/instrumentation-undici`), span names, and attributes (`code.function.name`, `db.query.text`, `sap.btp.destination`, the no-raw-SQL / no-URL-in-span-name checks). `captured` holds full ReadableSpans with `instrumentationScope`, so the filters just point at `captured`.

No flush/poll was needed: the spans for these single request/DB ops appear synchronously in `captured` after the awaited call. In `tracing-span-names.test.js`, `data.reset()` is itself traced, so the buffer is cleared *after* reset (mirroring `tracing-attributes.test.js`).

## Why

No more `console.dir` spying in the tracing tests. With all three files migrated, the `[tracing-attributes]` profile in `test/bookshop/.cdsrc.json` has no remaining consumers (verified: only these 3 used it; `tracing-attributes.test.js` despite its name already uses `tracing-in-memory`), so it is removed. This also resolves the deferred "rename tracing-attributes → tracing-console" note — the profile simply goes away.

Test-only change. No lib change, no CHANGELOG.

Refs #478 (group 1 only; group 2 done via #479, group 3 stays).