### PR TITLE
test: enable HTTP instrumentation in tests; assert incoming SERVER spans + traceparent propagation (#475)

### DIFF
--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -22,9 +22,7 @@
         "instrumentations": {
           "http": {
             "config": {
-              "ignoreIncomingRequestHook": "./lib/MyIgnoreIncomingRequestHook.js",
-              "disableIncomingRequestInstrumentation": true,
-              "disableOutgoingRequestInstrumentation": true
+              "ignoreIncomingRequestHook": "./lib/MyIgnoreIncomingRequestHook.js"
             }
           }
         },

--- a/test/tracing-messaging-inboxed.test.js
+++ b/test/tracing-messaging-inboxed.test.js
@@ -1,14 +1,18 @@
 const CASE = 'inboxed'
 
+const otel = require('@opentelemetry/api')
+
 // `inboxed: true` combined with the default outboxed messaging behavior means TWO queue
 // workers get involved per emit — one on the producer side (drains outbox to broker) and
 // one on the consumer side (drains inbox to subscribers). Each worker runs two
 // transactions (tx 1: lock; tx 2: handle + delete).
 //
 // Each worker iteration is wrapped by `cds.spawn`, so both txs collapse under a single
-// `cds.spawn - run task` root. 4 meaningful roots:
+// `cds.spawn - run task` root. With incoming HTTP instrumentation on, the producer trace is
+// rooted at the incoming SERVER span for the emit-triggering POST (AdminService - tx nests
+// under it). 4 meaningful roots:
 //
-//   1. AdminService - tx                    (producer: handle test_emit, UPSERT outbox)
+//   1. POST (incoming SERVER span)          (producer: AdminService - tx, handle test_emit, UPSERT outbox)
 //   2. cds.spawn - run task                  (outbox worker: dispatches to file)
 //        ├─ db - tx        (tx 1: lock)
 //        └─ messaging - tx (tx 2: handle foo — writes to file — + DELETE)
@@ -31,7 +35,8 @@ const CHECK = ({ expect, rootSpans, groupedByTrace }) => {
   // Producer trace
   const producer = groupedByTrace.find(g => g.all.some(s => s.name === 'AdminService - handle test_emit'))
   expect(producer, 'expected a producer trace').to.exist
-  expect(producer.root.name).to.equal('AdminService - tx')
+  expect(producer.root.kind, 'producer trace rooted at the incoming SERVER span').to.equal(otel.SpanKind.SERVER)
+  expect(producer.all.some(s => s.name === 'AdminService - tx')).to.be.true
   expect(producer.all.some(s => s.name === 'db - UPSERT cds.outbox.Messages')).to.be.true
 
   // The inbox worker must have run the application handler (SELECT Books).

--- a/test/tracing-messaging-persistent-outbox.test.js
+++ b/test/tracing-messaging-persistent-outbox.test.js
@@ -1,5 +1,7 @@
 const CASE = 'persistent-outbox'
 
+const otel = require('@opentelemetry/api')
+
 // REVISIT: even with profile "persistent-outbox", messaging kind and file from package.json wins
 process.env.cds_requires_messaging = JSON.stringify({
   kind: 'file-based-messaging',
@@ -18,13 +20,17 @@ process.env.cds_requires_messaging = JSON.stringify({
 // wraps to emit a single `cds.spawn - run task` CONSUMER root that both worker tx spans
 // nest under.
 //
+// With incoming HTTP instrumentation on, the producer trace is rooted at the incoming SERVER
+// span for the emit-triggering POST (AdminService - tx nests under it).
+//
 // Expected shape (3 meaningful roots, same for sqlite and HANA):
 //
-//   1. AdminService - tx                          (producer trace)
-//        └─ AdminService - handle test_emit
-//             └─ messaging - emit outgoing foo
-//                  └─ db - UPSERT cds.outbox.Messages
-//                       └─ cds.spawn - schedule task
+//   1. POST (incoming SERVER span)                (producer trace)
+//        └─ AdminService - tx
+//             └─ AdminService - handle test_emit
+//                  └─ messaging - emit outgoing foo
+//                       └─ db - UPSERT cds.outbox.Messages
+//                            └─ cds.spawn - schedule task
 //
 //   2. cds.spawn - run task                       (queue worker root)
 //        ├─ db - tx                               (tx 1)
@@ -44,7 +50,8 @@ const CHECK = ({ expect, rootSpans, groupedByTrace }) => {
   // Producer trace
   const producer = groupedByTrace.find(g => g.all.some(s => s.name === 'AdminService - handle test_emit'))
   expect(producer, 'expected a producer trace').to.exist
-  expect(producer.root.name).to.equal('AdminService - tx')
+  expect(producer.root.kind, 'producer trace rooted at the incoming SERVER span').to.equal(otel.SpanKind.SERVER)
+  expect(producer.all.some(s => s.name === 'AdminService - tx')).to.be.true
   expect(producer.all.some(s => s.name === 'messaging - emit outgoing foo')).to.be.true
   expect(producer.all.some(s => s.name === 'db - UPSERT cds.outbox.Messages')).to.be.true
   expect(producer.all.some(s => s.name === 'cds.spawn - schedule task')).to.be.true

--- a/test/tracing-messaging-without-outbox.test.js
+++ b/test/tracing-messaging-without-outbox.test.js
@@ -1,5 +1,7 @@
 const CASE = 'without-outbox'
 
+const otel = require('@opentelemetry/api')
+
 // REVISIT: even with profile "without-outbox", messaging kind and file from package.json wins
 process.env.cds_requires_messaging = JSON.stringify({
   kind: 'file-based-messaging',
@@ -11,11 +13,15 @@ process.env.cds_requires_messaging = JSON.stringify({
 // transaction (no queue worker). The file watcher delivers asynchronously as a new
 // SpanKind.CONSUMER root.
 //
+// With incoming HTTP instrumentation on, the producer trace is now rooted at the incoming
+// SERVER span (SpanKind.SERVER) for the emit-triggering POST; `AdminService - tx` nests under it.
+//
 // Expected roots:
-//   1. AdminService - tx                    (producer)
-//        └─ AdminService - handle test_emit
-//             └─ messaging - emit outgoing foo
-//                  └─ messaging - handle foo  (writes to file, in-process)
+//   1. POST (incoming SERVER span)          (producer)
+//        └─ AdminService - tx
+//             └─ AdminService - handle test_emit
+//                  └─ messaging - emit outgoing foo
+//                       └─ messaging - handle foo  (writes to file, in-process)
 //
 //   2. messaging - tx                       (file-based CONSUMER)
 //        └─ messaging - emit outgoing foo
@@ -29,7 +35,8 @@ const CHECK = ({ expect, rootSpans, groupedByTrace }) => {
   // Producer trace
   const producer = groupedByTrace.find(g => g.all.some(s => s.name === 'AdminService - handle test_emit'))
   expect(producer, 'expected a producer trace').to.exist
-  expect(producer.root.name).to.equal('AdminService - tx')
+  expect(producer.root.kind, 'producer trace rooted at the incoming SERVER span').to.equal(otel.SpanKind.SERVER)
+  expect(producer.all.some(s => s.name === 'AdminService - tx')).to.be.true
   expect(producer.all.some(s => s.name.match(/messaging - emit outgoing/))).to.be.true
 
   // File-based CONSUMER trace

--- a/test/tracing-messaging.js
+++ b/test/tracing-messaging.js
@@ -3,6 +3,14 @@ module.exports = (CASE, CHECK) => {
   const { expect, POST } = cds.test(__dirname + '/bookshop', '--profile', `${CASE},tracing-in-memory`)
   const { reset, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
   const otel = require('@opentelemetry/api')
+  const { suppressTracing } = require('@opentelemetry/core')
+
+  // The test's HTTP client runs in-process and, with outgoing HTTP instrumentation now enabled,
+  // would itself create a CLIENT span for the emit-triggering POST — an artificial extra root
+  // above the incoming SERVER span. Real callers are separate, un-instrumented processes, so we
+  // run the request under suppressTracing to model that: the outgoing CLIENT span is skipped and
+  // the incoming SERVER span is the producer trace's root.
+  const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
 
   const wait = require('node:timers/promises').setTimeout
 
@@ -99,7 +107,7 @@ module.exports = (CASE, CHECK) => {
   })
 
   test('emit is traced', async () => {
-    await POST('/odata/v4/admin/test_emit', {}, admin)
+    await asExternalClient(() => POST('/odata/v4/admin/test_emit', {}, admin))
     // Poll (flush + re-check) until both queue workers have run and exported their spans;
     // on HANA the worker latency exceeds any reasonable fixed sleep. Pass the meaningful
     // (non-outbox-scan) traces so the CHECK's exact root-count assertions aren't thrown off by

--- a/test/tracing-scheduled.test.js
+++ b/test/tracing-scheduled.test.js
@@ -6,10 +6,11 @@
 //
 // Expected meaningful roots (unified across sqlite and HANA):
 //
-//   1. AdminService - tx                       (producer trace)
-//        └─ AdminService - handle test_scheduled
-//             └─ db - UPSERT cds.outbox.Messages
-//                  └─ cds.spawn - schedule task
+//   1. POST (incoming SERVER span)             (producer trace)
+//        └─ AdminService - tx
+//             └─ AdminService - handle test_scheduled
+//                  └─ db - UPSERT cds.outbox.Messages
+//                       └─ cds.spawn - schedule task
 //
 //   2. cds.spawn - run task                    (queue worker root)
 //        ├─ db - tx                            (tx 1: lock)
@@ -22,8 +23,16 @@ const cds = require('@sap/cds')
 const { expect, POST } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'tracing-in-memory')
 const { reset, captured, groupedByTrace, rootSpans } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
+const { suppressTracing } = require('@opentelemetry/core')
 
 const wait = require('node:timers/promises').setTimeout
+
+// With incoming HTTP instrumentation on, the in-process test client would otherwise emit its own
+// outgoing CLIENT span for the POST — an artifact that pollutes the producer trace and can even be
+// picked as its root. Real callers are separate, un-instrumented processes, so run client requests
+// under suppressTracing to model that: the CLIENT span is skipped and the genuine incoming SERVER
+// span is the producer trace's root.
+const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
 
 // Force-flush the tracer provider's span processor so any spans buffered by background
 // queue/worker activity are exported into `captured`. The global provider is a
@@ -83,7 +92,7 @@ describe('tracing for scheduled tasks', () => {
   })
 
   test('schedule .after() is fully traced through the queue worker', async () => {
-    await POST('/odata/v4/admin/test_scheduled', {}, { auth: { username: 'alice' } })
+    await asExternalClient(() => POST('/odata/v4/admin/test_scheduled', {}, { auth: { username: 'alice' } }))
 
     // Poll (flush + re-check) until the scheduled task has fired and all spans have been
     // exported; on HANA the worker latency exceeds any reasonable fixed sleep.
@@ -91,7 +100,10 @@ describe('tracing for scheduled tasks', () => {
       // Producer trace: writes the task row inside the HTTP request tx.
       const producer = groupedByTrace().find(g => g.all.some(s => s.name === 'AdminService - handle test_scheduled'))
       expect(producer, 'expected a producer trace').to.exist
-      expect(producer.root.name).to.equal('AdminService - tx')
+      // With incoming HTTP instrumentation on, the producer trace roots at the incoming SERVER
+      // span for the POST; `AdminService - tx` now nests under it.
+      expect(producer.root.kind, 'producer trace rooted at the incoming SERVER span').to.equal(otel.SpanKind.SERVER)
+      expect(producer.all.some(s => s.name === 'AdminService - tx')).to.be.true
       expect(producer.all.some(s => s.name === 'db - UPSERT cds.outbox.Messages')).to.be.true
       expect(producer.all.some(s => s.name === 'cds.spawn - schedule task')).to.be.true
 

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -11,6 +11,14 @@ const { expect, GET, POST } = cds.test(__dirname + '/bookshop', '--profile', 'tr
 // console spying, no string-regex matching of formatted output.
 const { reset, rootSpans, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
+const { suppressTracing } = require('@opentelemetry/core')
+
+// The test's HTTP client runs in-process and, with outgoing HTTP instrumentation now enabled,
+// would itself create a CLIENT span for every request — an artificial extra root that also
+// overwrites any manually-set `traceparent` header. Real callers are separate, un-instrumented
+// processes, so we run client-side requests under suppressTracing to model that: the outgoing
+// CLIENT span is skipped, the incoming SERVER span is created normally by the server handler.
+const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
 
 const wait = require('node:timers/promises').setTimeout
 
@@ -67,12 +75,22 @@ describe('tracing', () => {
     expect(rootSpans().length).to.be.gte(1)
   })
 
-  // REVISIT: jest breaks otel's patching of incoming request handling -> no span for 'GET' -> behavior to test not reproducible
-  xtest('GET with traceparent is traced', async () => {
-    const config = { ...admin, headers: { traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' } }
-    const { status } = await GET('/odata/v4/admin/Books', config)
+  // With incoming HTTP instrumentation on, the SERVER span adopts the W3C trace context from the
+  // request's `traceparent` header: the whole request trace continues the given trace id and the
+  // SERVER span is a child of the given (external) span id.
+  test('GET with traceparent is traced', async () => {
+    const traceId = '0af7651916cd43dd8448eb211c80319c'
+    const parentSpanId = 'b7ad6b7169203331'
+    const config = { ...admin, headers: { traceparent: `00-${traceId}-${parentSpanId}-01` } }
+    const { status } = await asExternalClient(() => GET('/odata/v4/admin/Books', config))
     expect(status).to.equal(200)
     expect(captured.some(s => s.name === 'AdminService - READ AdminService.Books')).to.be.true
+    // The incoming SERVER span continued the propagated trace and parented off the external span id.
+    await eventually(() => {
+      const server = captured.find(s => s.kind === otel.SpanKind.SERVER && s.spanContext().traceId === traceId)
+      expect(server, 'incoming SERVER span adopting the propagated trace').to.exist
+      expect(server.parentSpanContext?.spanId).to.equal(parentSpanId)
+    })
   })
 
   test('custom GET is traced', async () => {
@@ -97,24 +115,60 @@ describe('tracing', () => {
     })
   })
 
-  // REVISIT: jest breaks otel's patching of incoming request handling -> behavior to test not reproducible
-  xtest('instrumentation hooks', async () => {})
+  // Incoming HTTP instrumentation produces a SERVER span (SpanKind.SERVER === 1) per request,
+  // carrying the mount-relative `url.path`. Two independent mechanisms suppress that span:
+  //   - the sampler's `ignoreIncomingPaths` (set at the top of this file for /odata/v4/admin/Authors)
+  //   - the `ignoreIncomingRequestHook` (MyIgnoreIncomingRequestHook: /odata/v4/admin/Authors + /Books(252))
+  // A non-ignored path still produces a SERVER span; the ignored paths must produce none.
+  test('instrumentation hooks', async () => {
+    const serverSpansFor = path =>
+      captured.filter(s => s.kind === otel.SpanKind.SERVER && s.attributes['url.path'] === path)
+
+    // Baseline: a non-ignored path DOES yield an incoming SERVER span.
+    await asExternalClient(() => GET('/odata/v4/admin/Books', admin))
+    await eventually(() => expect(serverSpansFor('/Books')).to.have.lengthOf(1))
+
+    // Sampler path: /odata/v4/admin/Authors is in ignoreIncomingPaths -> no SERVER span.
+    reset()
+    await asExternalClient(() => GET('/odata/v4/admin/Authors?$select=ID', admin))
+    await eventually(() => {
+      expect(captured.some(s => s.kind === otel.SpanKind.SERVER && s.attributes['url.path']?.includes('/Authors'))).to
+        .be.false
+    })
+
+    // ignoreIncomingRequestHook path: /Books(252) is ignored by the hook (not the sampler) -> no SERVER span.
+    reset()
+    await asExternalClient(() => GET('/odata/v4/admin/Books(252)', admin))
+    await eventually(() => {
+      expect(serverSpansFor('/Books(252)')).to.have.lengthOf(0)
+    })
+  })
 
   test('$batch is traced', async () => {
-    await POST(
-      '/odata/v4/genre/$batch',
-      {
-        requests: [
-          { id: 'r1', method: 'POST', url: '/Genres', headers: { 'content-type': 'application/json' }, body: {} },
-          { id: 'r2', method: 'GET', url: '/Genres', headers: {} }
-        ]
-      },
-      admin
+    await asExternalClient(() =>
+      POST(
+        '/odata/v4/genre/$batch',
+        {
+          requests: [
+            { id: 'r1', method: 'POST', url: '/Genres', headers: { 'content-type': 'application/json' }, body: {} },
+            { id: 'r2', method: 'GET', url: '/Genres', headers: {} }
+          ]
+        },
+        admin
+      )
     )
-    // With the tx wrap (lib/tracing/cds.js), each batch request's tx becomes a single root —
-    // the previously-visible 4 sub-roots (POST: CREATE + read-after-write; GET: read actives +
-    // read drafts) are now nested under 2 root tx spans, one per batch entry.
-    await eventually(() => expect(meaningfulRoots()).to.have.lengthOf(2))
+    // With incoming HTTP instrumentation on, the single $batch POST produces one incoming SERVER
+    // span that becomes the trace root. Both batch sub-requests (the POST -> CREATE Genres draft
+    // and the GET -> READ Genres) run within that request context, so their tx spans reparent
+    // under the SERVER span rather than surfacing as separate roots. Result: exactly 1 meaningful
+    // root (the SERVER span), containing both the CREATE and the READ sub-operations.
+    await eventually(() => {
+      const roots = meaningfulRoots()
+      expect(roots).to.have.lengthOf(1)
+      expect(roots[0].kind).to.equal(otel.SpanKind.SERVER)
+      expect(captured.some(s => s.name === 'GenreService - CREATE GenreService.Genres.drafts')).to.be.true
+      expect(captured.some(s => s.name === 'GenreService - READ GenreService.Genres')).to.be.true
+    })
   })
 
   test('cds.spawn is traced', async () => {


### PR DESCRIPTION
## What

Re-enables HTTP instrumentation in the test app (disabled by #474 to stay behavior-neutral under jest) and asserts the incoming-request tracing behavior it produces.

- **Test-app config** (`test/bookshop/package.json`): removed `disableIncomingRequestInstrumentation` / `disableOutgoingRequestInstrumentation` so both default to on; kept `ignoreIncomingRequestHook`. Incoming HTTP requests now produce a SERVER span (the root of each request trace) and outgoing requests produce CLIENT spans.
- **`GET with traceparent is traced`** (was `xtest`): asserts the incoming SERVER span adopts the W3C context from the `traceparent` header — trace id `0af7651916cd43dd8448eb211c80319c`, parent span id `b7ad6b7169203331`.
- **`instrumentation hooks`** (was empty `xtest`): asserts both suppression mechanisms — the sampler's `ignoreIncomingPaths` (`/odata/v4/admin/Authors`) and `MyIgnoreIncomingRequestHook` (`/Books(252)`) — produce NO incoming SERVER span, while a non-ignored path (`/Books`) does.
- **`$batch is traced`**: updated for reparenting — the single `$batch` POST now yields ONE incoming SERVER root with both batch sub-operations (CREATE Genres draft, READ Genres) nested beneath it (was 2 roots).
- **tracing-messaging CHECKs** (`without-outbox`, `inboxed`, `persistent-outbox`): the producer trace is now rooted at the incoming SERVER span (`AdminService - tx` nests under it), so the root assertion was updated from name `AdminService - tx` to `SpanKind.SERVER` while keeping the same nested-span assertions.

## Why

The test's HTTP client runs in-process; with outgoing instrumentation now on, it would itself create a CLIENT span (an artificial extra root that also overwrites a manually-set `traceparent`). A shared `asExternalClient` helper runs client-side requests under `suppressTracing` to model a real external, un-instrumented caller — the outgoing CLIENT artifact is skipped and the genuine incoming SERVER span is the trace root.

No `lib/` change (config + tests only). No CHANGELOG.

## Verification (sqlite)

- `test/tracing.test.js` — 11 passed / 2 skipped (the 2 formerly-`xtest` now real + passing; `$batch` fixed; #477 §3 stubs remain skipped)
- `test/tracing-remote-cloudsdk.test.js` + `test/tracing-remote-native.test.js` — pass (outgoing CLIENT instrumentation didn't break them)
- Full suite — 65 passed / 12 skipped (was 63 / 14; the 2 newly-enabled tests moved skipped→passed)
- lint + oxfmt clean; lockfile untouched

## HANA note

`inboxed` and `persistent-outbox` messaging tests are HANA-only (skipped on sqlite) but share the same reparented producer-root assertion, so they were updated too — HANA CI must be verified on this PR.

closes #475