### PR TITLE
test: centralize duplicated test helpers into test-utils (#488)

### DIFF
--- a/test/bookshop/lib/test-utils.js
+++ b/test/bookshop/lib/test-utils.js
@@ -1,0 +1,89 @@
+// Shared test helpers, centralized here so the ~10 tracing/metrics suites stop copy-pasting them.
+//
+// Kept dependency-light on purpose: it does NOT `require('@sap/cds')` at module top (doing so once
+// broke span capture for the sibling span exporter — the cds require has to happen inside the test
+// file, after the profile is applied). Only @opentelemetry primitives + node timers here.
+//
+// `clearOutbox` uses the global `DELETE` (the cds query API). That global is installed by cds.test()
+// in the test process, and clearOutbox is only ever called from within hooks/tests (after setup), so
+// the global is reliably present at call time — the module never needs to require @sap/cds itself.
+
+const otel = require('@opentelemetry/api')
+const { suppressTracing } = require('@opentelemetry/core')
+const { setTimeout: wait } = require('node:timers/promises')
+
+// The test's HTTP client runs in-process and, with outgoing HTTP instrumentation now enabled, would
+// itself create a CLIENT span for every request — an artificial extra root that also overwrites any
+// manually-set `traceparent` header. Real callers are separate, un-instrumented processes, so we run
+// client-side requests under suppressTracing to model that: the outgoing CLIENT span is skipped and
+// the incoming SERVER span is created normally by the server handler.
+const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
+
+// Best-effort outbox clear that can NEVER hang the surrounding hook. On the shared HANA HDI
+// container a background queue worker may be holding the connection pool (draining/retrying), so a
+// bare `DELETE` can block indefinitely — which previously turned into a hook timeout that starved
+// the pool and cascaded into ECONNREFUSED for the NEXT test file's server. Race the DELETE against a
+// short timeout and swallow errors: if it can't complete quickly, the leftover rows are handled by
+// the next file's own beforeEach clear anyway.
+async function clearOutbox(timeout = 5000) {
+  try {
+    await Promise.race([DELETE.from('cds.outbox.Messages'), wait(timeout)])
+  } catch {
+    // pool draining / server shutting down — nothing left to clean matters
+  }
+}
+
+// Force-flush the tracer provider's span processor so any spans buffered by background activity are
+// exported into `captured`. The global provider is a ProxyTracerProvider (no forceFlush) whose
+// delegate is the real NodeTracerProvider; guard for the no-op provider so a misconfigured profile
+// fails loudly, not silently.
+async function flushSpans() {
+  const provider = otel.trace.getTracerProvider()
+  const delegate = provider.getDelegate?.() ?? provider
+  if (typeof delegate.forceFlush === 'function') await delegate.forceFlush()
+}
+
+// State-based wait: repeatedly flush + re-run the assertion until it holds or times out. Replaces
+// the fixed `wait(...)` sleeps that flake on HANA, where background/spawned work flushes its data
+// after any reasonable fixed window.
+//
+// `flush` is the target to force before each re-check. It defaults to `flushSpans` (the span
+// callers). Metric callers pass the meter provider's `forceFlush` (exported by MyInMemoryMetricReader)
+// — passing it keeps this module from depending on the reader. Defaults (timeout 15000, interval 50)
+// match the span call sites; metric call sites pass their own timeout/interval explicitly.
+async function eventually(fn, { flush = flushSpans, timeout = 15000, interval = 50 } = {}) {
+  const start = Date.now()
+  let lastError
+  while (true) {
+    await flush()
+    try {
+      await fn()
+      return
+    } catch (err) {
+      lastError = err
+      if (Date.now() - start >= timeout) throw lastError
+      await wait(interval)
+    }
+  }
+}
+
+// On HANA the persistent-outbox queue scheduler periodically scans `cds.outbox.Messages` in its own
+// `db - tx` (a SELECT + optional UPDATE that finds nothing to dispatch). Those land as extra root
+// traces unrelated to the emit under test — and because the single HDI container is shared across all
+// test files, scans triggered by other files' lingering workers show up too. Filter those pure
+// outbox-scan traces so the exact root-count assertions stay stable. A scan trace is a `db - tx` root
+// whose every span only touches `cds.outbox.Messages` (no application entity, no messaging/handle span).
+const isOutboxScanTrace = g =>
+  g.root.name === 'db - tx' && g.all.every(s => s.name === 'db - tx' || s.name.includes('cds.outbox.Messages'))
+
+// Drop the outbox-scan bookkeeping traces from a `groupedByTrace()` array, returning the meaningful groups.
+const meaningful = groups => groups.filter(g => !isOutboxScanTrace(g))
+
+module.exports = {
+  asExternalClient,
+  clearOutbox,
+  flushSpans,
+  eventually,
+  isOutboxScanTrace,
+  meaningful
+}

--- a/test/bookshop/lib/test-utils.js
+++ b/test/bookshop/lib/test-utils.js
@@ -67,6 +67,13 @@ async function eventually(fn, { flush = flushSpans, timeout = 15000, interval = 
   }
 }
 
+// Build an `expectEventually(assertion)` bound to a specific flush target + poll defaults, so the
+// metric suites don't each re-declare the same one-line wrapper. Metric callers pass the meter
+// provider's `forceFlush` and their own {timeout, interval} (which vary per suite); the returned
+// helper takes just the assertion. Equivalent to `a => eventually(a, { flush, timeout, interval })`.
+const makeExpectEventually = (flush, { timeout, interval } = {}) => assertion =>
+  eventually(assertion, { flush, timeout, interval })
+
 // On HANA the persistent-outbox queue scheduler periodically scans `cds.outbox.Messages` in its own
 // `db - tx` (a SELECT + optional UPDATE that finds nothing to dispatch). Those land as extra root
 // traces unrelated to the emit under test — and because the single HDI container is shared across all
@@ -84,6 +91,7 @@ module.exports = {
   clearOutbox,
   flushSpans,
   eventually,
+  makeExpectEventually,
   isOutboxScanTrace,
   meaningful
 }

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -4,7 +4,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { eventually } = require('./bookshop/lib/test-utils')
+const { makeExpectEventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET, axios } = cds.test(
   __dirname + '/bookshop',
@@ -23,7 +23,7 @@ function metricValue(tenant, metric) {
 // completes the instant the in-memory per-tenant queue statistics (kept fresh by the existing
 // cds.spawn poller) reflect the asserted state. forceFlush() throws fast if the provider isn't
 // wired, so a misconfigured profile fails loudly instead of busy-spinning the full timeout.
-const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 10000, interval: 25 })
+const expectEventually = makeExpectEventually(forceFlush, { timeout: 10000, interval: 25 })
 
 // Multitenancy needs a bound BTP Service Manager (MTX) to provision per-tenant HDI containers.
 // The HANA CI runs against a single pre-provisioned HDI container with no Service Manager, so this

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -4,6 +4,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
+const { eventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET, axios } = cds.test(
   __dirname + '/bookshop',
@@ -17,26 +18,12 @@ function metricValue(tenant, metric) {
   return latestDataPointValue(metric, { 'sap.tenancy.tenant_id': tenant })
 }
 
-// State-based wait: force the wired meter provider to collect + export, then re-run the assertion
-// block. Replaces all fixed-time `wait(…)` sleeps — the loop completes the instant the in-memory
-// per-tenant queue statistics (kept fresh by the existing cds.spawn poller) reflect the asserted
-// state. forceFlush() throws fast if the provider isn't wired, so a misconfigured profile fails
-// loudly instead of busy-spinning the full timeout.
-async function expectEventually(assertion, { timeout = 10000, interval = 25 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await forceFlush()
-    try {
-      assertion()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
+// State-based wait for metric assertions: force the wired meter provider (forceFlush) to collect +
+// export, then re-run the assertion block. Replaces all fixed-time `wait(…)` sleeps — the loop
+// completes the instant the in-memory per-tenant queue statistics (kept fresh by the existing
+// cds.spawn poller) reflect the asserted state. forceFlush() throws fast if the provider isn't
+// wired, so a misconfigured profile fails loudly instead of busy-spinning the full timeout.
+const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 10000, interval: 25 })
 
 // Multitenancy needs a bound BTP Service Manager (MTX) to provision per-tenant HDI containers.
 // The HANA CI runs against a single pre-provisioned HDI container with no Service Manager, so this

--- a/test/metrics-outbox-multitenant.test.js
+++ b/test/metrics-outbox-multitenant.test.js
@@ -4,7 +4,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { makeExpectEventually } = require('./bookshop/lib/test-utils')
+const { makeExpectEventually } = require('./utils')
 
 const { expect, GET, axios } = cds.test(
   __dirname + '/bookshop',

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -9,7 +9,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { clearOutbox, eventually } = require('./bookshop/lib/test-utils')
+const { clearOutbox, makeExpectEventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET, axios } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'metrics-outbox')
 axios.defaults.validateStatus = () => true
@@ -32,7 +32,7 @@ function metricValue(metric, queuedServiceName) {
 // Polling at 500ms (with the profile's exportIntervalMillis raised to 1000ms) leaves the worker
 // enough DB headroom to make all its attempts. The loop still returns the instant the state holds,
 // so sqlite (per-file in-memory DB) still satisfies in well under a second.
-const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 30000, interval: 500 })
+const expectEventually = makeExpectEventually(forceFlush, { timeout: 30000, interval: 500 })
 
 const debugLog = (cds.log('telemetry').debug = vi.fn(() => {}))
 

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -9,6 +9,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
+const { clearOutbox, eventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET, axios } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'metrics-outbox')
 axios.defaults.validateStatus = () => true
@@ -17,25 +18,11 @@ function metricValue(metric, queuedServiceName) {
   return latestDataPointValue(metric, { 'queue.name': queuedServiceName })
 }
 
-// Best-effort outbox clear that can NEVER hang the surrounding hook. On the shared HANA HDI
-// container a background queue worker may be holding the connection pool (draining/retrying),
-// so a bare `DELETE` can block indefinitely — which previously turned into a 100s hook timeout
-// that starved the pool and cascaded into ECONNREFUSED for the NEXT test file's server. Race the
-// DELETE against a short timeout and swallow errors: if it can't complete quickly, the leftover
-// rows are handled by the next file's own beforeEach clear anyway.
-async function clearOutbox(timeout = 5000) {
-  try {
-    await Promise.race([DELETE.from('cds.outbox.Messages'), wait(timeout)])
-  } catch {
-    // pool draining / server shutting down — nothing left to clean matters
-  }
-}
-
-// State-based wait: force the wired meter provider to collect + export, then re-run the assertion
-// block. Replaces all fixed-time `wait(150)` sleeps — the loop completes the instant the in-memory
-// queue statistics (kept fresh by the queue-stats cds.spawn poller) reflect the asserted state.
-// forceFlush() throws fast if the provider isn't wired, so a misconfigured profile fails loudly
-// instead of busy-spinning the full timeout.
+// State-based wait for metric assertions: force the wired meter provider (forceFlush) to collect +
+// export, then re-run the assertion block. Replaces all fixed-time `wait(150)` sleeps — the loop
+// completes the instant the in-memory queue statistics (kept fresh by the queue-stats cds.spawn
+// poller) reflect the asserted state. forceFlush() throws fast if the provider isn't wired, so a
+// misconfigured profile fails loudly instead of busy-spinning the full timeout.
 //
 // interval is 500ms (NOT a few ms): each forceFlush() triggers a metric collection that runs the
 // queue-stats poller's SELECTs against the DB. On the SHARED HANA HDI container a tight poll loop
@@ -45,21 +32,7 @@ async function clearOutbox(timeout = 5000) {
 // Polling at 500ms (with the profile's exportIntervalMillis raised to 1000ms) leaves the worker
 // enough DB headroom to make all its attempts. The loop still returns the instant the state holds,
 // so sqlite (per-file in-memory DB) still satisfies in well under a second.
-async function expectEventually(assertion, { timeout = 30000, interval = 500 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await forceFlush()
-    try {
-      assertion()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
+const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 30000, interval: 500 })
 
 const debugLog = (cds.log('telemetry').debug = vi.fn(() => {}))
 

--- a/test/metrics-outbox.test.js
+++ b/test/metrics-outbox.test.js
@@ -9,7 +9,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 // Exported metric data is captured in-memory by MyInMemoryMetricReader (wired via the
 // metrics-outbox profile in .cdsrc.json) instead of scraping ConsoleMetricExporter's console.dir.
 const { latestDataPointValue, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { clearOutbox, makeExpectEventually } = require('./bookshop/lib/test-utils')
+const { clearOutbox, makeExpectEventually } = require('./utils')
 
 const { expect, GET, axios } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'metrics-outbox')
 axios.defaults.validateStatus = () => true

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -6,7 +6,7 @@
 const cds = require('@sap/cds')
 
 const { captured, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { makeExpectEventually } = require('./bookshop/lib/test-utils')
+const { makeExpectEventually } = require('./utils')
 
 const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'metrics')
 

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -4,31 +4,17 @@
 // log output. The formatting of those metrics is unit-tested in console-metric-exporter.test.js.
 
 const cds = require('@sap/cds')
-const { setTimeout: wait } = require('node:timers/promises')
 
 const { captured, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
+const { eventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'metrics')
 
-// State-based wait: force the wired meter provider to collect + export, then re-run the assertion
-// block. Replaces fixed-time sleeps — the loop completes the instant the captured datapoints
-// reflect the asserted state. forceFlush() throws fast if the provider isn't wired, so a
-// misconfigured profile fails loudly instead of busy-spinning the full timeout.
-async function expectEventually(assertion, { timeout = 10000, interval = 25 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await forceFlush()
-    try {
-      assertion()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
+// State-based wait for metric assertions: force the wired meter provider (forceFlush) to collect +
+// export, then re-run the assertion block. Replaces fixed-time sleeps — the loop completes the
+// instant the captured datapoints reflect the asserted state. forceFlush() throws fast if the
+// provider isn't wired, so a misconfigured profile fails loudly instead of busy-spinning the timeout.
+const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 10000, interval: 25 })
 
 // All metric descriptor names present across every captured export.
 function capturedMetricNames() {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -6,7 +6,7 @@
 const cds = require('@sap/cds')
 
 const { captured, forceFlush, reset } = require('./bookshop/lib/MyInMemoryMetricReader')
-const { eventually } = require('./bookshop/lib/test-utils')
+const { makeExpectEventually } = require('./bookshop/lib/test-utils')
 
 const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'metrics')
 
@@ -14,7 +14,7 @@ const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'metrics'
 // export, then re-run the assertion block. Replaces fixed-time sleeps — the loop completes the
 // instant the captured datapoints reflect the asserted state. forceFlush() throws fast if the
 // provider isn't wired, so a misconfigured profile fails loudly instead of busy-spinning the timeout.
-const expectEventually = assertion => eventually(assertion, { flush: forceFlush, timeout: 10000, interval: 25 })
+const expectEventually = makeExpectEventually(forceFlush, { timeout: 10000, interval: 25 })
 
 // All metric descriptor names present across every captured export.
 function capturedMetricNames() {

--- a/test/tracing-messaging.js
+++ b/test/tracing-messaging.js
@@ -2,72 +2,11 @@ module.exports = (CASE, CHECK) => {
   const cds = require('@sap/cds')
   const { expect, POST } = cds.test(__dirname + '/bookshop', '--profile', `${CASE},tracing-in-memory`)
   const { reset, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
-  const otel = require('@opentelemetry/api')
-  const { suppressTracing } = require('@opentelemetry/core')
-
-  // The test's HTTP client runs in-process and, with outgoing HTTP instrumentation now enabled,
-  // would itself create a CLIENT span for the emit-triggering POST — an artificial extra root
-  // above the incoming SERVER span. Real callers are separate, un-instrumented processes, so we
-  // run the request under suppressTracing to model that: the outgoing CLIENT span is skipped and
-  // the incoming SERVER span is the producer trace's root.
-  const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
+  const { asExternalClient, clearOutbox, eventually, meaningful } = require('./bookshop/lib/test-utils')
 
   const wait = require('node:timers/promises').setTimeout
 
-  // Best-effort outbox clear that can NEVER hang the surrounding hook. On the shared HANA HDI
-  // container a background queue worker may hold the connection pool, so a bare DELETE can block
-  // indefinitely — which would turn into a hook timeout that starves the pool and cascades into
-  // ECONNREFUSED for the next file's server. Race the DELETE against a short timeout; leftover
-  // rows are cleared by the next file's own beforeEach anyway.
-  async function clearOutbox(timeout = 5000) {
-    try {
-      await Promise.race([DELETE.from('cds.outbox.Messages'), wait(timeout)])
-    } catch {
-      // pool draining during shutdown — nothing left to clean matters
-    }
-  }
-
-  // Force-flush the tracer provider's span processor so any spans buffered by background
-  // queue-worker activity are exported into `captured`. The global provider is a
-  // ProxyTracerProvider (no forceFlush) whose delegate is the real NodeTracerProvider;
-  // guard for the no-op provider so a misconfigured profile fails loudly, not silently.
-  async function flushSpans() {
-    const provider = otel.trace.getTracerProvider()
-    const delegate = provider.getDelegate?.() ?? provider
-    if (typeof delegate.forceFlush === 'function') await delegate.forceFlush()
-  }
-
-  // State-based wait: repeatedly flush + re-run the assertion until it holds or times out.
-  // Replaces the fixed `wait(waitMs)` sleep that flakes on HANA, where the two queue workers
-  // flush their spans well after any reasonable fixed window.
-  async function eventually(fn, { timeout = 15000, interval = 50 } = {}) {
-    const start = Date.now()
-    let lastError
-    while (true) {
-      await flushSpans()
-      try {
-        await fn()
-        return
-      } catch (err) {
-        lastError = err
-        if (Date.now() - start >= timeout) throw lastError
-        await wait(interval)
-      }
-    }
-  }
-
   const admin = { auth: { username: 'alice' } }
-
-  // The queue scheduler periodically scans `cds.outbox.Messages` in its own `db - tx` (a
-  // SELECT + optional UPDATE that finds nothing to dispatch). On HANA these bookkeeping scans
-  // land as extra root traces that have nothing to do with the emit under test — and because
-  // the single HDI container is shared across all test files, scans triggered by other files'
-  // lingering workers show up too. Filter those pure outbox-scan traces so the CHECKs' exact
-  // root-count assertions stay stable. A scan trace is a `db - tx` root whose every span only
-  // touches `cds.outbox.Messages` (no application entity, no messaging/handle span).
-  const isOutboxScanTrace = g =>
-    g.root.name === 'db - tx' && g.all.every(s => s.name === 'db - tx' || s.name.includes('cds.outbox.Messages'))
-  const meaningful = groups => groups.filter(g => !isOutboxScanTrace(g))
 
   const rm = () => {
     try {

--- a/test/tracing-messaging.js
+++ b/test/tracing-messaging.js
@@ -2,7 +2,7 @@ module.exports = (CASE, CHECK) => {
   const cds = require('@sap/cds')
   const { expect, POST } = cds.test(__dirname + '/bookshop', '--profile', `${CASE},tracing-in-memory`)
   const { reset, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
-  const { asExternalClient, clearOutbox, eventually, meaningful } = require('./bookshop/lib/test-utils')
+  const { asExternalClient, clearOutbox, eventually, meaningful } = require('./utils')
 
   const wait = require('node:timers/promises').setTimeout
 

--- a/test/tracing-outboxed-batch.test.js
+++ b/test/tracing-outboxed-batch.test.js
@@ -6,7 +6,7 @@ const cds = require('@sap/cds')
 const { expect, POST } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'tracing-in-memory')
 const { reset, captured, groupedByTrace } = require('./bookshop/lib/MyInMemorySpanExporter')
 const { hrTimeToNanoseconds } = require('@opentelemetry/core')
-const { eventually } = require('./bookshop/lib/test-utils')
+const { eventually } = require('./utils')
 
 describe('tracing for outboxed batch (chunk-size fan-out)', () => {
   // Queue-worker spans need cds.spawn on sqlite (pending cds fix). REMOVE with follow-up PR.

--- a/test/tracing-outboxed-batch.test.js
+++ b/test/tracing-outboxed-batch.test.js
@@ -6,38 +6,7 @@ const cds = require('@sap/cds')
 const { expect, POST } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'tracing-in-memory')
 const { reset, captured, groupedByTrace } = require('./bookshop/lib/MyInMemorySpanExporter')
 const { hrTimeToNanoseconds } = require('@opentelemetry/core')
-const otel = require('@opentelemetry/api')
-
-const wait = require('node:timers/promises').setTimeout
-
-// Force-flush the tracer provider's span processor so any spans buffered by background
-// outbox/queue activity are exported into `captured`. The global provider is a
-// ProxyTracerProvider (no forceFlush) whose delegate is the real NodeTracerProvider;
-// guard for the no-op provider so a misconfigured profile fails loudly, not silently.
-async function flushSpans() {
-  const provider = otel.trace.getTracerProvider()
-  const delegate = provider.getDelegate?.() ?? provider
-  if (typeof delegate.forceFlush === 'function') await delegate.forceFlush()
-}
-
-// State-based wait: repeatedly flush + re-run the assertion until it holds or times out.
-// Replaces fixed `wait(...)` sleeps that flake on HANA, where background work flushes spans
-// after the sleep window.
-async function eventually(fn, { timeout = 15000, interval = 50 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await flushSpans()
-    try {
-      await fn()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
+const { eventually } = require('./bookshop/lib/test-utils')
 
 describe('tracing for outboxed batch (chunk-size fan-out)', () => {
   // Queue-worker spans need cds.spawn on sqlite (pending cds fix). REMOVE with follow-up PR.

--- a/test/tracing-scheduled.test.js
+++ b/test/tracing-scheduled.test.js
@@ -23,45 +23,7 @@ const cds = require('@sap/cds')
 const { expect, POST } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'tracing-in-memory')
 const { reset, captured, groupedByTrace, rootSpans } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
-const { suppressTracing } = require('@opentelemetry/core')
-
-const wait = require('node:timers/promises').setTimeout
-
-// With incoming HTTP instrumentation on, the in-process test client would otherwise emit its own
-// outgoing CLIENT span for the POST — an artifact that pollutes the producer trace and can even be
-// picked as its root. Real callers are separate, un-instrumented processes, so run client requests
-// under suppressTracing to model that: the CLIENT span is skipped and the genuine incoming SERVER
-// span is the producer trace's root.
-const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
-
-// Force-flush the tracer provider's span processor so any spans buffered by background
-// queue/worker activity are exported into `captured`. The global provider is a
-// ProxyTracerProvider (no forceFlush) whose delegate is the real NodeTracerProvider;
-// guard for the no-op provider so a misconfigured profile fails loudly, not silently.
-async function flushSpans() {
-  const provider = otel.trace.getTracerProvider()
-  const delegate = provider.getDelegate?.() ?? provider
-  if (typeof delegate.forceFlush === 'function') await delegate.forceFlush()
-}
-
-// State-based wait: repeatedly flush + re-run the assertion until it holds or times out.
-// Replaces fixed `wait(...)` sleeps that flake on HANA, where the worker flushes spans after
-// the sleep window.
-async function eventually(fn, { timeout = 15000, interval = 50 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await flushSpans()
-    try {
-      await fn()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
+const { asExternalClient, eventually } = require('./bookshop/lib/test-utils')
 
 describe('tracing for scheduled tasks', () => {
   // Queue-worker spans (cds.spawn - run task root) require @sap/cds to route the sqlite

--- a/test/tracing-scheduled.test.js
+++ b/test/tracing-scheduled.test.js
@@ -23,7 +23,7 @@ const cds = require('@sap/cds')
 const { expect, POST } = cds.test(__dirname + '/bookshop', '--with-mocks', '--profile', 'tracing-in-memory')
 const { reset, captured, groupedByTrace, rootSpans } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
-const { asExternalClient, eventually } = require('./bookshop/lib/test-utils')
+const { asExternalClient, eventually } = require('./utils')
 
 describe('tracing for scheduled tasks', () => {
   // Queue-worker spans (cds.spawn - run task root) require @sap/cds to route the sqlite

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -11,55 +11,9 @@ const { expect, GET, POST } = cds.test(__dirname + '/bookshop', '--profile', 'tr
 // console spying, no string-regex matching of formatted output.
 const { reset, rootSpans, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
-const { suppressTracing } = require('@opentelemetry/core')
+const { asExternalClient, eventually, meaningful } = require('./bookshop/lib/test-utils')
 
-// The test's HTTP client runs in-process and, with outgoing HTTP instrumentation now enabled,
-// would itself create a CLIENT span for every request — an artificial extra root that also
-// overwrites any manually-set `traceparent` header. Real callers are separate, un-instrumented
-// processes, so we run client-side requests under suppressTracing to model that: the outgoing
-// CLIENT span is skipped, the incoming SERVER span is created normally by the server handler.
-const asExternalClient = fn => otel.context.with(suppressTracing(otel.context.active()), fn)
-
-const wait = require('node:timers/promises').setTimeout
-
-// Force-flush the tracer provider's span processor so any spans buffered by background
-// activity are exported into `captured`. The global provider is a ProxyTracerProvider (no
-// forceFlush) whose delegate is the real NodeTracerProvider; guard for the no-op provider
-// so a misconfigured profile fails loudly, not silently.
-async function flushSpans() {
-  const provider = otel.trace.getTracerProvider()
-  const delegate = provider.getDelegate?.() ?? provider
-  if (typeof delegate.forceFlush === 'function') await delegate.forceFlush()
-}
-
-// State-based wait: repeatedly flush + re-run the assertion until it holds or times out.
-// Replaces fixed `wait(...)` sleeps that flake on HANA, where spawned/emitted work flushes
-// spans after the sleep window.
-async function eventually(fn, { timeout = 15000, interval = 50 } = {}) {
-  const start = Date.now()
-  let lastError
-  while (true) {
-    await flushSpans()
-    try {
-      await fn()
-      return
-    } catch (err) {
-      lastError = err
-      if (Date.now() - start >= timeout) throw lastError
-      await wait(interval)
-    }
-  }
-}
-
-// On HANA the persistent-outbox queue poller periodically scans `cds.outbox.Messages` in its
-// own `db - tx`, producing an extra root trace that is unrelated to what these tests exercise.
-// Filter those bookkeeping traces out so root-count assertions stay stable across both DBs.
-const isOutboxScanTrace = g =>
-  g.root.name === 'db - tx' && g.all.every(s => s.name === 'db - tx' || s.name.includes('cds.outbox.Messages'))
-const meaningfulRoots = () =>
-  groupedByTrace()
-    .filter(g => !isOutboxScanTrace(g))
-    .flatMap(g => g.roots)
+const meaningfulRoots = () => meaningful(groupedByTrace()).flatMap(g => g.roots)
 
 describe('tracing', () => {
   const admin = { auth: { username: 'alice' } }

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -11,7 +11,7 @@ const { expect, GET, POST } = cds.test(__dirname + '/bookshop', '--profile', 'tr
 // console spying, no string-regex matching of formatted output.
 const { reset, rootSpans, groupedByTrace, captured } = require('./bookshop/lib/MyInMemorySpanExporter')
 const otel = require('@opentelemetry/api')
-const { asExternalClient, eventually, meaningful } = require('./bookshop/lib/test-utils')
+const { asExternalClient, eventually, meaningful } = require('./utils')
 
 const meaningfulRoots = () => meaningful(groupedByTrace()).flatMap(g => g.roots)
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -71,8 +71,10 @@ async function eventually(fn, { flush = flushSpans, timeout = 15000, interval = 
 // metric suites don't each re-declare the same one-line wrapper. Metric callers pass the meter
 // provider's `forceFlush` and their own {timeout, interval} (which vary per suite); the returned
 // helper takes just the assertion. Equivalent to `a => eventually(a, { flush, timeout, interval })`.
-const makeExpectEventually = (flush, { timeout, interval } = {}) => assertion =>
-  eventually(assertion, { flush, timeout, interval })
+const makeExpectEventually =
+  (flush, { timeout, interval } = {}) =>
+  assertion =>
+    eventually(assertion, { flush, timeout, interval })
 
 // On HANA the persistent-outbox queue scheduler periodically scans `cds.outbox.Messages` in its own
 // `db - tx` (a SELECT + optional UPDATE that finds nothing to dispatch). Those land as extra root

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 // Shared test helpers, centralized here so the ~10 tracing/metrics suites stop copy-pasting them.
 //
 // Kept dependency-light on purpose: it does NOT `require('@sap/cds')` at module top (doing so once
-// broke span capture for the sibling span exporter — the cds require has to happen inside the test
+// broke span capture for the in-memory span exporter — the cds require has to happen inside the test
 // file, after the profile is applied). Only @opentelemetry primitives + node timers here.
 //
 // `clearOutbox` uses the global `DELETE` (the cds query API). That global is installed by cds.test()


### PR DESCRIPTION
## What

Extracts the six test helpers that had been copy-pasted across ~10 test files into one shared module, `test/bookshop/lib/test-utils.js`:

- `flushSpans()` — unwrap the ProxyTracerProvider → delegate and `forceFlush()`.
- `eventually(fn, { flush, timeout, interval })` — the unified state-based poll. The span `eventually` and the metric `expectEventually` were structurally identical, differing only in the flush target + defaults, so they are now one function. `flush` defaults to `flushSpans` (span callers); metric callers pass the reader's `forceFlush` and their own timeout/interval.
- `clearOutbox(timeout = 5000)` — timeout-bounded `DELETE FROM cds.outbox.Messages`.
- `asExternalClient(fn)` — runs `fn` under `suppressTracing`.
- `isOutboxScanTrace(g)` / `meaningful(groups)` — the outbox-scan-trace filter, reconciled to a single `meaningful(groups)` signature.

## Why

These helpers landed independently during the HANA / instrumentation work and drifted into ~10 near-identical copies. Centralizing them removes the duplication (net -141 lines) and gives one place to maintain the polling / flush / outbox-scan-filter logic.

## Notes

- **Behavior-preserving refactor** — no assertion changes, no timeout/interval drift (each call site passes through its original values), no predicate changes.
- Test-only. No `lib/**` change, no CHANGELOG (test-only), no dependency change.
- `test-utils.js` stays dependency-light: it only requires `@opentelemetry/api`, `@opentelemetry/core`, and `node:timers/promises` — it does **not** `require('@sap/cds')` at module top (same rule that protects the sibling exporters/reader). `clearOutbox` uses the global `DELETE` provided by `cds.test()` at call time.

## Verification

- Full sqlite suite: **65 passed / 12 skipped** — matches the develop baseline exactly.
- Per-file runs (metrics-outbox, metrics-outbox-multitenant, metrics, tracing, tracing-messaging-without-outbox) all pass; the sqlite-gated tracing files (outboxed-batch, scheduled) skip as before.
- eslint `--max-warnings=0` clean, `oxfmt --check` clean.

## HANA CI

Several affected files run **only on HANA** and share these helpers, so they cannot be validated locally — please confirm HANA CI is green for:
- `test/tracing-scheduled.test.js`
- `test/tracing-messaging-inboxed.test.js`
- `test/tracing-messaging-persistent-outbox.test.js`
- `test/tracing-outboxed-batch.test.js`

(`test/tracing-messaging-without-outbox.test.js` does run on sqlite and exercises the shared `meaningful`/`eventually` path — confirmed passing.)

closes #488