### PR TITLE
test: configure via .cdsrc.json profiles instead of process.env.cds_* (#486)

### DIFF
--- a/test/bookshop/.cdsrc.json
+++ b/test/bookshop/.cdsrc.json
@@ -1,8 +1,19 @@
 {
+  "requires": {
+    "messaging": {
+      "kind": "local-messaging",
+      "_kind": "file-based-messaging",
+      "file": "../msg-box"
+    }
+  },
+  "log": {
+    "cls_custom_fields": ["tenant_id"]
+  },
   "[logging]": {
     "requires": {
       "telemetry": {
         "tracing": {
+          "exporter": false,
           "sampler": {
             "ignoreIncomingPaths": ["/odata/v4/admin/Genres"]
           }
@@ -85,6 +96,27 @@
           }
         }
       }
+    }
+  },
+  "[sampler-ignore-authors]": {
+    "requires": {
+      "telemetry": {
+        "tracing": {
+          "sampler": {
+            "ignoreIncomingPaths": ["/odata/v4/admin/Authors"]
+          }
+        }
+      }
+    }
+  },
+  "[native-fetch]": {
+    "remote": {
+      "native_fetch": true
+    }
+  },
+  "[no-scheduling]": {
+    "requires": {
+      "scheduling": false
     }
   },
   "[persistent-outbox]": {

--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -39,11 +39,6 @@
           }
         }
       },
-      "messaging": {
-        "kind": "local-messaging",
-        "_kind": "file-based-messaging",
-        "file": "../msg-box"
-      },
       "queue": {
         "legacyLocking": false
       },
@@ -75,11 +70,6 @@
           }
         }
       }
-    },
-    "log": {
-      "cls_custom_fields": [
-        "tenant_id"
-      ]
     },
     "fiori": {
       "draft_deletion_timeout": false

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,14 +1,13 @@
 /* eslint-disable no-console */
 
-// REVISIT: even with profile "logging", cls_custom_fields from package.json wins
-process.env.cds_log = JSON.stringify({ cls_custom_fields: ['foo'] })
-
-// This test asserts the exported LogRecords only. Disable the tracing signal (no exporter →
-// lib/tracing/index.js bails out early) so the queue SchedulingService's outbox-scan "elapsed
-// times:" trace primer is never produced and can't land in the console.dir spy window. Without
-// this, on HANA the outbox poll fires later than any fixed drain and the primer flakes the count.
-process.env.cds_requires_telemetry_tracing = JSON.stringify({ exporter: false })
-
+// Config lives in the `[logging]` profile of test/bookshop/.cdsrc.json:
+//   - log.cls_custom_fields: ['foo'] (the base default from package.json's cds.log moved to
+//     .cdsrc.json so this profile can win — see #486; package.json config loads after .cdsrc.json
+//     and would otherwise override the profile)
+//   - requires.telemetry.tracing.exporter: false to disable the tracing signal (no exporter →
+//     lib/tracing/index.js bails out early) so the queue SchedulingService's outbox-scan "elapsed
+//     times:" trace primer is never produced and can't land in the console.dir spy window. Without
+//     this, on HANA the outbox poll fires later than any fixed drain and the primer flakes the count.
 const cds = require('@sap/cds')
 const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'logging')
 

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 
 // Config lives in the `[logging]` profile of test/bookshop/.cdsrc.json:
-//   - log.cls_custom_fields: ['foo'] (the base default from package.json's cds.log moved to
-//     .cdsrc.json so this profile can win — see #486; package.json config loads after .cdsrc.json
-//     and would otherwise override the profile)
+//   - log.cls_custom_fields: ['foo'] — the profile's own override (the base default is
+//     ['tenant_id']). #486 moved the base `cds.log`/`messaging` defaults out of package.json into
+//     .cdsrc.json base so profiles can win: package.json config loads AFTER .cdsrc.json and would
+//     otherwise override any profile.
 //   - requires.telemetry.tracing.exporter: false to disable the tracing signal (no exporter →
 //     lib/tracing/index.js bails out early) so the queue SchedulingService's outbox-scan "elapsed
 //     times:" trace primer is never produced and can't land in the console.dir spy window. Without

--- a/test/passport.test.js
+++ b/test/passport.test.js
@@ -2,11 +2,11 @@ process.env.SAP_PASSPORT = 'true'
 
 // CDS v10 enables scheduling by default; its periodic outbox reads run in
 // their own transactions and cause spurious SAP_PASSPORT set/reset pairs on
-// the connection, breaking the deterministic _count assertions below.
-process.env.cds_requires_scheduling = 'false'
-
+// the connection, breaking the deterministic _count assertions below. The
+// `no-scheduling` profile (requires.scheduling: false) in test/bookshop/.cdsrc.json
+// disables it.
 const cds = require('@sap/cds')
-const { expect, GET } = cds.test().in(__dirname + '/bookshop')
+const { expect, GET } = cds.test(__dirname + '/bookshop', '--profile', 'no-scheduling')
 
 describe('SAP Passport', () => {
   if (cds.env.requires.db.kind === 'sqlite') return test.skip('n/a for SQLite', () => {})

--- a/test/tracing-attributes.test.js
+++ b/test/tracing-attributes.test.js
@@ -1,8 +1,8 @@
 // Use native fetch in CDS OQ so @opentelemetry/instrumentation-undici can see outbound calls
-process.env.cds_remote_native__fetch = 'true'
-
+// (cds.env.remote.native_fetch = true), configured via the `native-fetch` profile in
+// test/bookshop/.cdsrc.json, composed with `tracing-in-memory`.
 const cds = require('@sap/cds')
-const { expect, data } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
+const { expect, data } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory, native-fetch')
 const http = require('http')
 
 // The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures

--- a/test/tracing-messaging-inboxed.test.js
+++ b/test/tracing-messaging-inboxed.test.js
@@ -24,13 +24,8 @@ const otel = require('@opentelemetry/api')
 //
 // Tolerated: allow one extra root for the scheduling-service bookkeeping startup scan.
 
-// REVISIT: profile config wins for kind/file, but explicit env override sidesteps it.
-process.env.cds_requires_messaging = JSON.stringify({
-  kind: 'file-based-messaging',
-  file: `../${CASE}`,
-  inboxed: true
-})
-
+// Messaging config (kind/file/inboxed) comes from the `inboxed` profile in
+// test/bookshop/.cdsrc.json, composed with `tracing-in-memory` by the shared harness.
 const CHECK = ({ expect, rootSpans, groupedByTrace }) => {
   // Producer trace
   const producer = groupedByTrace.find(g => g.all.some(s => s.name === 'AdminService - handle test_emit'))

--- a/test/tracing-messaging-persistent-outbox.test.js
+++ b/test/tracing-messaging-persistent-outbox.test.js
@@ -2,11 +2,8 @@ const CASE = 'persistent-outbox'
 
 const otel = require('@opentelemetry/api')
 
-// REVISIT: even with profile "persistent-outbox", messaging kind and file from package.json wins
-process.env.cds_requires_messaging = JSON.stringify({
-  kind: 'file-based-messaging',
-  file: `../${CASE}`
-})
+// Messaging config (kind/file) comes from the `persistent-outbox` profile in
+// test/bookshop/.cdsrc.json, composed with `tracing-in-memory` by the shared harness.
 
 // --- Span hierarchy for the persistent-outbox case ---------------------------------------
 //

--- a/test/tracing-messaging-without-outbox.test.js
+++ b/test/tracing-messaging-without-outbox.test.js
@@ -2,12 +2,8 @@ const CASE = 'without-outbox'
 
 const otel = require('@opentelemetry/api')
 
-// REVISIT: even with profile "without-outbox", messaging kind and file from package.json wins
-process.env.cds_requires_messaging = JSON.stringify({
-  kind: 'file-based-messaging',
-  file: `../${CASE}`,
-  outboxed: false
-})
+// Messaging config (kind/file/outboxed) comes from the `without-outbox` profile in
+// test/bookshop/.cdsrc.json, composed with `tracing-in-memory` by the shared harness.
 
 // Without outbox, file-based messaging writes directly to the file from the producer's
 // transaction (no queue worker). The file watcher delivers asynchronously as a new

--- a/test/tracing-remote-native.test.js
+++ b/test/tracing-remote-native.test.js
@@ -1,9 +1,8 @@
-// Force CAP to use native fetch for outbound remote calls (instead of the cloud sdk).
-// This must be set before @sap/cds is loaded, so it lives at the very top of the file.
-process.env.cds_remote_native__fetch = 'true'
-
+// Force CAP to use native fetch for outbound remote calls (instead of the cloud sdk) via the
+// `native-fetch` profile (cds.env.remote.native_fetch = true) in test/bookshop/.cdsrc.json,
+// composed with `tracing-in-memory`.
 const cds = require('@sap/cds')
-const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory, native-fetch')
 const http = require('http')
 
 // The tracing-in-memory profile (see test/bookshop/.cdsrc.json) configures

--- a/test/tracing.test.js
+++ b/test/tracing.test.js
@@ -1,10 +1,12 @@
 // REVISIT: jest breaks otel's patching of incoming request handling -> we can't ignore via ignoreIncomingRequestHook
-process.env.cds_requires_telemetry_tracing_sampler = JSON.stringify({
-  ignoreIncomingPaths: ['/odata/v4/admin/Authors']
-})
-
+// The sampler's ignoreIncomingPaths (/odata/v4/admin/Authors) is configured via the
+// `sampler-ignore-authors` profile in test/bookshop/.cdsrc.json, composed with `tracing-in-memory`.
 const cds = require('@sap/cds')
-const { expect, GET, POST } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
+const { expect, GET, POST } = cds.test(
+  __dirname + '/bookshop',
+  '--profile',
+  'tracing-in-memory, sampler-ignore-authors'
+)
 
 // Assert against the structured ReadableSpan objects captured by MyInMemorySpanExporter
 // (configured via the tracing-in-memory profile in test/bookshop/.cdsrc.json) — no


### PR DESCRIPTION
## What

Replaces the load-order-fragile `process.env.cds_requires_*` / `process.env.cds_*` string-JSON test config with proper cds config: `.cdsrc.json` profiles (composed with `--profile`) and `cds.test()` args. Test-only + test-app-config change; no `lib/` change.

## Why

Setting config via `process.env.cds_*` string-JSON at module top is load-order-sensitive: it must run before any `@sap/cds` require or it is silently ignored (the root of the removed `delete cds.env` hack). cds already supports the same config declaratively via `.cdsrc.json` profiles.

Root cause of the old `// REVISIT: ... package.json wins` comments (why some config had to be done via env): cds loads config sources sequentially, `package.json` **after** `.cdsrc.json`, last-writer-wins. So a `.cdsrc.json` profile could never override a key that `package.json` set at its base. Fix: move those base defaults (`log.cls_custom_fields`, `messaging.kind`/`file`) from `test/bookshop/package.json` into `test/bookshop/.cdsrc.json` base, so the `.cdsrc.json` profiles (same source) win as intended.

## Sites moved to profiles (all 8 — zero `process.env.cds_*` remain)

| Site | Was | Now |
|---|---|---|
| `logging.test.js` (cls_custom_fields, tracing.exporter:false) | `cds_log`, `cds_requires_telemetry_tracing` | `[logging]` profile (+ base moved out of package.json) |
| `tracing.test.js` (sampler ignoreIncomingPaths) | `cds_requires_telemetry_tracing_sampler` | new `[sampler-ignore-authors]` profile, `--profile 'tracing-in-memory, sampler-ignore-authors'` |
| `tracing-remote-native.test.js`, `tracing-attributes.test.js` (native_fetch) | `cds_remote_native__fetch` | new `[native-fetch]` profile (`remote.native_fetch: true`), `--profile 'tracing-in-memory, native-fetch'` |
| `passport.test.js` (scheduling off) | `cds_requires_scheduling` | new `[no-scheduling]` profile, `cds.test(dir, '--profile', 'no-scheduling')` |
| `tracing-messaging-{inboxed,persistent-outbox,without-outbox}.test.js` (messaging kind/file/flags) | `cds_requires_messaging` | existing `[inboxed]`/`[persistent-outbox]`/`[without-outbox]` profiles now fully carry it (messaging base moved out of package.json) |

## .cdsrc.json changes

- Added base `requires.messaging` (local-messaging / msg-box) and `log.cls_custom_fields` (moved from package.json).
- `[logging]`: added `requires.telemetry.tracing.exporter: false`.
- New profiles: `[sampler-ignore-authors]`, `[native-fetch]`, `[no-scheduling]`.

## Verification

- Full sqlite suite: **65 passed / 12 skipped** (identical to baseline, same skip set).
- Each converted file passes individually on sqlite.
- `grep -rn "process.env.cds_" test/` → none remain.
- eslint (test/) + oxfmt clean; `grep -c int.repositories.cloud.sap package-lock.json` = 0.

## HANA CI caveat

Profile changes are DB-agnostic, but these run on HANA and could only be validated for config equivalence locally (config resolves identically to the old env), not executed: `logging` (runs on both), and the HANA-only `tracing-messaging-inboxed` + `tracing-messaging-persistent-outbox`. HANA CI must validate them.

No lib change. No behavior change.

Closes #486
