### PR TITLE
chore: back-merge CODEOWNERS (#495) into develop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cap-js/node-js-runtime


### PR DESCRIPTION
Back-merges `main` into `develop` so develop is up-to-date with main. Sole delta is `.github/CODEOWNERS` (added directly to main via #495). Required to clear the `BEHIND` state on the standing release PR #471 (develop → main) so v2.1.0 can be promoted.