### PR TITLE
feat: configurable span processor via telemetry.tracing.processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Queue worker transactions are traced as coherent `<service> - tx` spans under the `cds.spawn - run task` root, instead of orphaned per-call spans
+- The span processor is now configurable via `cds.requires.telemetry.tracing.processor = { kind, config? }` (`BatchSpanProcessor` or `SimpleSpanProcessor`); defaults to `BatchSpanProcessor`, and to `SimpleSpanProcessor` in the `[development]` profile
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,9 @@ Default: `BatchSpanProcessor`, except in the `[development]` profile, which uses
 }
 ```
 
+> [!NOTE]
+> The `ConsoleSpanExporter` (the default `telemetry-to-console` exporter) has only been tested with the `SimpleSpanProcessor`. Combining it with the `BatchSpanProcessor` is not recommended.
+
 
 ### Exporters
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Documentation can be found at [cap.cloud.sap](https://cap.cloud.sap/docs) and [o
   - [Instrumentations](#instrumentations)
   - [Sampler](#sampler)
   - [Propagators](#propagators)
+  - [Span Processor](#span-processor)
   - [Exporters](#exporters)
   - [High Resolution Timestamps (beta)](#high-resolution-timestamps-beta)
   - [Environment Variables](#environment-variables)
@@ -425,6 +426,18 @@ Configure via `cds.requires.telemetry.tracing.propagators = [<name> | { module, 
 Default:
 ```json
 ["W3CTraceContextPropagator", "W3CBaggagePropagator"]
+```
+
+
+### Span Processor
+
+Configure via `cds.requires.telemetry.tracing.processor = { kind, config? }`, where `kind` is one of `BatchSpanProcessor` or `SimpleSpanProcessor` and `config` is passed through to the processor's constructor.
+
+Default: `BatchSpanProcessor`, except in the `[development]` profile, which uses `SimpleSpanProcessor` so spans are exported immediately.
+```json
+{
+  "kind": "BatchSpanProcessor"
+}
 ```
 
 

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -166,11 +166,10 @@ module.exports = resource => {
     LOG._info && LOG.info('Dynatrace OneAgent detected, disabling trace exporter')
   } else {
     const exporter = _getExporter()
-    const processorConfig = cds.env.requires.telemetry.tracing.processor?.config || {}
-    processor =
-      process.env.NODE_ENV === 'production'
-        ? new BatchSpanProcessor(exporter, processorConfig)
-        : new SimpleSpanProcessor(exporter, processorConfig)
+    const { kind: processorKind, config: processorConfig } = cds.env.requires.telemetry.tracing.processor || {}
+    const processors = { BatchSpanProcessor, SimpleSpanProcessor }
+    if (!processors[processorKind]) throw new Error(`Unknown span processor ${processorKind}`)
+    processor = new processors[processorKind](exporter, processorConfig)
   }
 
   /*

--- a/lib/tracing/index.js
+++ b/lib/tracing/index.js
@@ -166,7 +166,7 @@ module.exports = resource => {
     LOG._info && LOG.info('Dynatrace OneAgent detected, disabling trace exporter')
   } else {
     const exporter = _getExporter()
-    const { kind: processorKind, config: processorConfig } = cds.env.requires.telemetry.tracing.processor || {}
+    const { kind: processorKind, config: processorConfig = {} } = cds.env.requires.telemetry.tracing.processor || {}
     const processors = { BatchSpanProcessor, SimpleSpanProcessor }
     if (!processors[processorKind]) throw new Error(`Unknown span processor ${processorKind}`)
     processor = new processors[processorKind](exporter, processorConfig)

--- a/package.json
+++ b/package.json
@@ -81,11 +81,17 @@
               "W3CTraceContextPropagator",
               "W3CBaggagePropagator"
             ],
-            "[development]": {
-              "hrtime": true
+            "processor": {
+              "kind": "BatchSpanProcessor"
             },
             "_tx": false,
-            "_hana_prom": true
+            "_hana_prom": true,
+            "[development]": {
+              "hrtime": true,
+              "processor": {
+                "kind": "SimpleSpanProcessor"
+              }
+            }
           },
           "metrics": {
             "config": {

--- a/test/bookshop/.cdsrc.json
+++ b/test/bookshop/.cdsrc.json
@@ -144,5 +144,16 @@
         "outboxed": false
       }
     }
+  },
+  "[tracing-batch-processor]": {
+    "requires": {
+      "telemetry": {
+        "tracing": {
+          "processor": {
+            "kind": "BatchSpanProcessor"
+          }
+        }
+      }
+    }
   }
 }

--- a/test/tracing-processor-batch.test.js
+++ b/test/tracing-processor-batch.test.js
@@ -1,0 +1,31 @@
+// Tests that an explicit processor override activates BatchSpanProcessor.
+//
+// The `[tracing-batch-processor]` profile in test/bookshop/.cdsrc.json explicitly
+// sets `telemetry.tracing.processor.kind = "BatchSpanProcessor"`, overriding the
+// `[development]` profile default of SimpleSpanProcessor. This proves the explicit-
+// override path: a single config knob flips the active processor in a dev-profile run.
+//
+// NOTE: a "true production profile" boot (NODE_ENV=production or --profile production)
+// is not feasible in the test bookshop — the production profile requires @cap-js/hana
+// which is not installed. The production default (BatchSpanProcessor, defined in
+// package.json's base tracing config) is therefore covered via this explicit override
+// rather than a genuine production boot.
+const cds = require('@sap/cds')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory, tracing-batch-processor')
+const otel = require('@opentelemetry/api')
+
+// Same accessor as in tracing-processor-simple.test.js — see that file for rationale.
+function activeProcessorName() {
+  const provider = otel.trace.getTracerProvider()
+  const delegate = provider.getDelegate?.() ?? provider
+  return delegate._activeSpanProcessor?._spanProcessors?.[0]?.constructor?.name
+}
+
+describe('span processor selection — explicit BatchSpanProcessor override', () => {
+  test('tracing-batch-processor profile activates BatchSpanProcessor', () => {
+    // The [tracing-batch-processor] profile overrides the [development] default
+    // (SimpleSpanProcessor) to BatchSpanProcessor — the same processor production uses,
+    // proven here via explicit override in a dev-profile run.
+    expect(activeProcessorName()).toBe('BatchSpanProcessor')
+  })
+})

--- a/test/tracing-processor-simple.test.js
+++ b/test/tracing-processor-simple.test.js
@@ -1,0 +1,34 @@
+// Tests that the development profile selects SimpleSpanProcessor.
+//
+// Per package.json `cds.requires.kinds.telemetry.tracing`, the package-level default
+// (production) processor is BatchSpanProcessor; the `[development]` profile in
+// package.json overrides it to SimpleSpanProcessor. In the test environment
+// (NODE_ENV != production) the `[development]` profile applies automatically, so a
+// plain boot should yield SimpleSpanProcessor without any additional override.
+const cds = require('@sap/cds')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
+const otel = require('@opentelemetry/api')
+
+// Reach the active span processor installed by the tracing factory.
+//
+// The global OTel provider is a ProxyTracerProvider (returned by trace.getTracerProvider());
+// getDelegate() unwraps it to the real NodeTracerProvider built by lib/tracing/index.js.
+// NodeTracerProvider wraps all registered processors in a private MultiSpanProcessor
+// accessible as _activeSpanProcessor. We drill one level deeper to _spanProcessors[0]
+// (the single processor the factory installed) to read its constructor name.
+// _spanProcessors is a private `_`-prefixed field, but it is the only stable path to the
+// live processor instance; `flushSpans()` in test/utils.js follows the same
+// getDelegate() + forceFlush() pattern for the same reason.
+function activeProcessorName() {
+  const provider = otel.trace.getTracerProvider()
+  const delegate = provider.getDelegate?.() ?? provider
+  return delegate._activeSpanProcessor?._spanProcessors?.[0]?.constructor?.name
+}
+
+describe('span processor selection — development profile', () => {
+  test('development profile activates SimpleSpanProcessor', () => {
+    // [development] is auto-applied in non-production (NODE_ENV=test) environments.
+    // The plugin should have wired a SimpleSpanProcessor (not the batch default).
+    expect(activeProcessorName()).toBe('SimpleSpanProcessor')
+  })
+})

--- a/test/tracing-processor-unknown.test.js
+++ b/test/tracing-processor-unknown.test.js
@@ -1,0 +1,25 @@
+// Tests that an unknown processor kind causes the tracing factory to throw.
+//
+// Boot the bookshop server so cds.env is fully configured with the tracing-in-memory
+// profile, then call the real tracing factory (lib/tracing/index.js) with a bogus
+// processor kind. The factory throws before creating the tracerProvider or calling
+// .register(), so passing {} as the resource arg is safe and causes no double-register.
+// require('./cds')() and require('./cloud_sdk')() run first, but both use the wrap()
+// utility which guards against double-wrapping via the __wrapped flag — idempotent.
+const cds = require('@sap/cds')
+const { expect } = cds.test(__dirname + '/bookshop', '--profile', 'tracing-in-memory')
+
+const tracing = require('../lib/tracing')
+
+describe('span processor selection — unknown kind', () => {
+  test('unknown processor kind throws with a descriptive error', () => {
+    const cfg = cds.env.requires.telemetry.tracing
+    const orig = cfg.processor
+    try {
+      cfg.processor = { kind: 'NotARealProcessor' }
+      expect(() => tracing({})).toThrow(/Unknown span processor NotARealProcessor/)
+    } finally {
+      cfg.processor = orig
+    }
+  })
+})


### PR DESCRIPTION
Closes #411.

### Problem
The span processor was hard-coded off `NODE_ENV`: `BatchSpanProcessor` in production, `SimpleSpanProcessor` otherwise. There was no way to override it (e.g. force `SimpleSpanProcessor` in a prod-like env for immediate export, or tune batching `config`).

### Change
Select the processor from config: `cds.requires.telemetry.tracing.processor = { kind, config? }`.

- `kind` ∈ { `BatchSpanProcessor` (default), `SimpleSpanProcessor` }
- `config` is passed through to the processor's constructor
- The `[development]` profile defaults to `SimpleSpanProcessor` — so the previous `NODE_ENV`-based behavior is preserved (production → Batch, dev → Simple), just now overridable.
- An unknown `kind` throws `Unknown span processor <kind>`, mirroring the existing `sampler`/`propagator` kind-validation in `lib/tracing/index.js`.

### Tests
- `test/tracing-processor-simple.test.js` — dev profile boot activates `SimpleSpanProcessor`.
- `test/tracing-processor-batch.test.js` — explicit `[tracing-batch-processor]` override activates `BatchSpanProcessor` (a true `production` boot isn't feasible in the test app — it requires `@cap-js/hana`; the production default is covered via this explicit override).
- `test/tracing-processor-unknown.test.js` — an unknown kind throws via the real factory (verified non-vacuous: removing the guard makes it fail).

### Docs
- README: new **Span Processor** config section.
- CHANGELOG: `Added` bullet under 2.1.0.